### PR TITLE
feat: add default values for environment variables in Astro configuration

### DIFF
--- a/astro.config.mts
+++ b/astro.config.mts
@@ -26,14 +26,17 @@ export default defineConfig({
       GITHUB_REPO_URL: envField.string({
         context: "client",
         access: "public",
+        default: "https://github.com/Semkoo/niko-table-registry",
       }),
       DEPLOY_PRIME_URL: envField.string({
         context: "client",
         access: "public",
+        default: "http://localhost:4321",
       }),
       URL: envField.string({
         context: "client",
         access: "public",
+        default: "https://niko-table.com",
       }),
     },
   },


### PR DESCRIPTION


- Added default value for GITHUB_REPO_URL: "https://github.com/Semkoo/niko-table-registry"
- Added default value for DEPLOY_PRIME_URL: "http://localhost:4321"
- Added default value for URL: "https://niko-table.com"