### PR TITLE
docs: document every internal helper + refresh manual-installation tree

### DIFF
--- a/src/content/docs/getting-started/manual-installation.mdx
+++ b/src/content/docs/getting-started/manual-installation.mdx
@@ -113,18 +113,19 @@ your-project/
 │   │   │   └── ...                # Other Shadcn components
 │   │   │
 │   │   └── niko-table/
-│   │       ├── index.tsx                    # Main exports
 │   │       │
 │   │       ├── core/                        # Core table components
-│   │       │   ├── data-table-root.tsx
-│   │       │   ├── data-table.tsx
-│   │       │   ├── data-table-context.tsx
-│   │       │   ├── data-table-structure.tsx  # Header, Body, EmptyBody, Skeleton, Loading (consolidated)
-│   │       │   ├── data-table-virtualized-structure.tsx  # VirtualizedHeader, VirtualizedBody, VirtualizedEmptyBody, VirtualizedSkeleton, VirtualizedLoading (consolidated)
-│   │       │   └── index.tsx
+│   │       │   ├── data-table.tsx                                  # Container + scroll wrapper
+│   │       │   ├── data-table-root.tsx                             # Top-level provider + table options
+│   │       │   ├── data-table-context.tsx                          # useDataTable() context
+│   │       │   ├── data-table-error-boundary.tsx                   # Error boundary wrapper
+│   │       │   ├── data-table-structure.tsx                        # Header, Body, EmptyBody, Skeleton, Loading, LoadingMore
+│   │       │   ├── data-table-dnd-structure.tsx                    # Row-DnD + Column-DnD non-virtualized bodies
+│   │       │   ├── data-table-virtualized-structure.tsx            # VirtualizedHeader, VirtualizedBody, VirtualizedEmptyBody, VirtualizedSkeleton, VirtualizedLoading, VirtualizedLoadingMore
+│   │       │   └── data-table-virtualized-dnd-structure.tsx        # VirtualizedDndBody, VirtualizedDndHeader, VirtualizedDndColumnBody (deep-import only)
 │   │       │
-│   │       ├── components/                  # All user-facing components
-│   │       │   ├── data-table-search-filter.tsx      # Context-aware components
+│   │       ├── components/                  # Context-aware user-facing components
+│   │       │   ├── data-table-search-filter.tsx
 │   │       │   ├── data-table-view-menu.tsx
 │   │       │   ├── data-table-filter-menu.tsx
 │   │       │   ├── data-table-sort-menu.tsx
@@ -135,43 +136,66 @@ your-project/
 │   │       │   ├── data-table-inline-filter.tsx
 │   │       │   ├── data-table-pagination.tsx
 │   │       │   ├── data-table-export-button.tsx
-│   │       │   ├── table-column-header.tsx            # Reusable UI components
+│   │       │   ├── data-table-row-dnd.tsx
+│   │       │   ├── data-table-column-dnd.tsx
+│   │       │   ├── data-table-column-actions.tsx
+│   │       │   ├── data-table-column-header.tsx
+│   │       │   ├── data-table-column-title.tsx
+│   │       │   ├── data-table-column-sort.tsx
+│   │       │   ├── data-table-column-hide.tsx
+│   │       │   ├── data-table-column-pin.tsx
+│   │       │   ├── data-table-column-filter.tsx
+│   │       │   ├── data-table-column-filter-trigger.tsx
+│   │       │   ├── data-table-column-faceted-filter.tsx
+│   │       │   ├── data-table-column-date-filter-options.tsx
+│   │       │   ├── data-table-column-slider-filter-options.tsx
 │   │       │   ├── data-table-aside.tsx
 │   │       │   ├── data-table-selection-bar.tsx
 │   │       │   ├── data-table-toolbar-section.tsx
-│   │       │   ├── data-table-empty-state.tsx
-│   │       │   └── index.tsx
+│   │       │   └── data-table-empty-state.tsx
 │   │       │
-│   │       ├── filters/                     # Core implementation components
+│   │       ├── filters/                     # Core filter implementations (accept `table` prop directly)
 │   │       │   ├── table-search-filter.tsx
 │   │       │   ├── table-faceted-filter.tsx
 │   │       │   ├── table-slider-filter.tsx
+│   │       │   ├── table-range-filter.tsx
 │   │       │   ├── table-date-filter.tsx
 │   │       │   ├── table-inline-filter.tsx
 │   │       │   ├── table-filter-menu.tsx
+│   │       │   ├── table-clear-filter.tsx
 │   │       │   ├── table-view-menu.tsx
-│   │       │   ├── table-sort-menu.tsx
-│   │       │   ├── table-range-filter.tsx
 │   │       │   ├── table-pagination.tsx
 │   │       │   ├── table-export-button.tsx
-│   │       │   └── index.tsx
+│   │       │   ├── table-row-dnd.tsx
+│   │       │   ├── table-column-dnd.tsx
+│   │       │   ├── table-column-actions.tsx
+│   │       │   ├── table-column-title.tsx
+│   │       │   ├── table-column-sort.tsx
+│   │       │   ├── table-column-hide.tsx
+│   │       │   ├── table-column-pin.tsx
+│   │       │   ├── table-column-faceted-filter.tsx
+│   │       │   ├── table-column-slider-filter.tsx
+│   │       │   └── table-column-date-filter.tsx
 │   │       │
-│   │       ├── config/                      # Configuration
+│   │       ├── config/                      # Configuration + feature detection
 │   │       │   ├── data-table.ts
-│   │       │   ├── feature-detection.ts
-│   │       │   └── index.tsx
+│   │       │   └── feature-detection.ts
 │   │       │
 │   │       ├── hooks/                       # Custom React hooks
+│   │       │   ├── use-debounce.ts
 │   │       │   ├── use-derived-column-title.ts
-│   │       │   ├── use-keyboard-shortcut.ts
-│   │       │   └── index.ts
+│   │       │   ├── use-generated-options.ts
+│   │       │   └── use-keyboard-shortcut.ts
 │   │       │
 │   │       ├── lib/                         # Utility functions
 │   │       │   ├── constants.ts
 │   │       │   ├── data-table.ts
 │   │       │   ├── filter-functions.ts
+│   │       │   ├── filter-rows.ts
+│   │       │   ├── build-faceted-options.ts
 │   │       │   ├── format.ts
-│   │       │   └── index.ts
+│   │       │   ├── styles.ts
+│   │       │   └── create-scroll-handler.ts                        # Shared scroll-listener factory used by every body
 │   │       │
 │   │       └── types/                       # TypeScript types
 │   │           └── index.ts

--- a/src/content/docs/niko-table/overview/components.mdx
+++ b/src/content/docs/niko-table/overview/components.mdx
@@ -1280,3 +1280,169 @@ Context-aware wrapper for `TableDragAlongCell`. Cell follows column drag positio
 | `cell`      | `Cell<TData, TValue>` | -       | TanStack Table cell instance (required). |
 | `children`  | `React.ReactNode`     | -       | Cell content.                            |
 | `className` | `string`              | -       | Additional CSS classes.                  |
+
+## Column Header Internal Helpers
+
+The column header system is split into a composable set of files. `DataTableColumnHeader` (documented above) is the user-facing entry point that consumers render in their column `header` callbacks. The pieces below are the building blocks it uses internally — they are exported so consumers building a fully custom header can drop in just the parts they need (e.g. only the sort menu, or only the pin/hide actions), but most consumers won't import them directly.
+
+Each module is a thin wrapper around the corresponding `filters/table-column-*` filter (which holds the TanStack-Table-aware logic) and adds context wiring + UI chrome via `useColumnHeaderContext`.
+
+### data-table-column-actions
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/components/data-table-column-actions.tsx`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+Renders the trailing dropdown-menu trigger on a column header (the `⋮` button). Composed from the column-sort, column-hide, column-pin, and column-faceted-filter primitives — pulls in only the items relevant to the column's `meta` configuration. Used inside `DataTableColumnHeader`.
+
+### data-table-column-title
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/components/data-table-column-title.tsx`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+Renders the column's title text (resolved from `column.columnDef.meta?.label` or the accessor key via `useDerivedColumnTitle`). Wraps the corresponding `TableColumnTitle` from `filters/`.
+
+### data-table-column-sort
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/components/data-table-column-sort.tsx`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+Renders the per-column sort menu items (Asc / Desc / Clear) with the variant-aware icons from `SORT_ICONS` / `SORT_LABELS`. Honors `column.getCanSort()` — renders nothing when sorting is disabled. Wraps `TableColumnSort` from `filters/`.
+
+### data-table-column-hide
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/components/data-table-column-hide.tsx`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+Renders the "Hide column" menu item. Honors `column.getCanHide()`. Wraps `TableColumnHide` from `filters/`.
+
+### data-table-column-pin
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/components/data-table-column-pin.tsx`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+Renders the "Pin to left" / "Pin to right" / "Unpin" menu items. Honors `column.getCanPin()`. Wraps `TableColumnPin` from `filters/`.
+
+### data-table-column-filter
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/components/data-table-column-filter.tsx`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+Routes a column to the right per-column filter UI based on `column.columnDef.meta?.variant` (text / number / range / date / select / multi_select / boolean). Lazy-mounts the variant-specific filter component (`data-table-column-faceted-filter`, `data-table-column-slider-filter-options`, `data-table-column-date-filter-options`) only when the user opens the filter panel.
+
+### data-table-column-filter-trigger
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/components/data-table-column-filter-trigger.tsx`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+The `<button>` shown in the column header that opens the per-column filter popover. Switches its label / active state based on whether the column currently has a filter value.
+
+### data-table-column-faceted-filter
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/components/data-table-column-faceted-filter.tsx`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+The per-column variant of the faceted multi-select filter (used for `select` / `multi_select` column variants). Generates options via `useGeneratedOptions` and forwards `dynamicCounts` / `limitToFilteredRows` props through to the option builder. Wraps `TableColumnFacetedFilter` from `filters/`.
+
+### data-table-column-date-filter-options
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/components/data-table-column-date-filter-options.tsx`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+The per-column date / date-range filter UI (date picker + operator selector). Backed by `TableColumnDateFilter` from `filters/`. Lazily mounted by `data-table-column-filter` when the column variant is `date` / `date_range`.
+
+### data-table-column-slider-filter-options
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/components/data-table-column-slider-filter-options.tsx`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+The per-column numeric range slider UI. Resolves `min` / `max` from the column's faceted min/max values when not explicitly set. Backed by `TableColumnSliderFilter` from `filters/`. Lazily mounted by `data-table-column-filter` when the column variant is `range`.

--- a/src/content/docs/niko-table/overview/lib.mdx
+++ b/src/content/docs/niko-table/overview/lib.mdx
@@ -555,3 +555,61 @@ import { ERROR_MESSAGES } from "@/components/niko-table/lib/constants"
 // Available messages:
 ERROR_MESSAGES.DEPRECATED_GLOBAL_JOIN_OPERATOR
 ```
+
+## Faceted Options Builder
+
+Used internally by faceted-filter components to translate a raw column dataset into the `{ label, value, count }` shape the filter UI consumes. Documented for completeness — most consumers won't import it directly.
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/lib/build-faceted-options.ts`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+### buildFacetedOptions
+
+Walks a TanStack Table column / row set and produces deduplicated `{ label, value, count }` entries for the faceted-filter dropdown. Honors the `dynamicCounts` flag so counts update reactively when other filters change. Used internally by `DataTableFacetedFilter` and `TableColumnFacetedFilter`.
+
+```tsx showLineNumbers
+import { buildFacetedOptions } from "@/components/niko-table/lib/build-faceted-options"
+
+const options = buildFacetedOptions({
+  rows: table.getCoreRowModel().rows,
+  columnId: "category",
+  dynamicCounts: true,
+})
+// → [{ label: "Electronics", value: "electronics", count: 12 }, ...]
+```
+
+#### Notes
+
+- This module is consumed by the faceted-filter wrappers; if you're building a custom faceted UI, `useGeneratedOptions` (in `hooks/`) is the consumer-facing surface that wraps this helper with React state.
+- Runs in O(n) over the column's cell values; safe to call per render for typical column counts.
+
+## Row Filtering Helpers
+
+Internal helpers that resolve `globalFilter` / column-filter combinations to a final visible row set. Used by `DataTableRoot` when wiring `tableOptions.getFilteredRowModel`.
+
+<div className="mb-4 flex gap-2">
+  <Button variant="outline" size="sm" asChild>
+    <a
+      href={`${GITHUB_REPO_URL}/blob/main/src/components/niko-table/lib/filter-rows.ts`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Source Code ↗
+    </a>
+  </Button>
+</div>
+
+### filter-rows.ts
+
+Provides the row-filtering logic that backs the table's filtered row model — combines per-column filters with the global filter, applies the right `extendedFilter` / `globalFilter` / `numberRangeFilter` / `dateRangeFilter` based on column meta, and returns the visible row set.
+
+This module is internal to the table's filter pipeline. Consumers normally interact with it indirectly via `tableOptions.filterFns` (which `DataTableRoot` wires automatically). If you're building a fully custom filter pipeline you can import the named helpers from this file directly — see the source for the current export surface.


### PR DESCRIPTION
## Summary

Closes a doc-vs-filesystem audit by adding documentation for every previously-undocumented internal helper module under `src/components/niko-table/`, and refreshing the project-structure tree on the manual-installation page so it matches reality.

## Audit findings (against the actual filesystem)

Three docs pages had gaps:

### 1. `/getting-started/manual-installation/` — project-structure tree

Was missing ~30 files. Tree refreshed to match the filesystem; obsolete `index.tsx` / `index.ts` barrel entries removed (the sources don't have them); short descriptions added on the new files.

**New entries now present in the tree:**

- `core/`: `data-table-error-boundary.tsx`, `data-table-dnd-structure.tsx`, `data-table-virtualized-dnd-structure.tsx`
- `components/`: 13 column-*, row-dnd, column-dnd files
- `filters/`: 11 column-*, row-dnd files
- `hooks/`: `use-debounce.ts`, `use-generated-options.ts`
- `lib/`: `build-faceted-options.ts`, `filter-rows.ts`, `styles.ts`, `create-scroll-handler.ts`

### 2. `/niko-table/overview/lib/`

Two utility files had no documentation. Added two new sections:

- **`buildFacetedOptions`** — internal helper that produces `{label, value, count}` entries for the faceted-filter dropdown. Documented for completeness; consumers normally interact via `useGeneratedOptions`.
- **`filter-rows.ts`** — internal row-filtering pipeline that backs `tableOptions.getFilteredRowModel`. Source link + usage notes.

### 3. `/niko-table/overview/components/`

10 column-header internal helpers had zero or near-zero documentation. Added a single **"Column Header Internal Helpers"** section with one entry per file, each with a Source Code link + a short paragraph explaining what the module does and where it's used inside the column-header composition:

`data-table-column-actions`, `-title`, `-sort`, `-hide`, `-pin`, `-filter`, `-filter-trigger`, `-faceted-filter`, `-date-filter-options`, `-slider-filter-options`.

## Pages that were already complete

- `/niko-table/overview/core/` — already covers all 8 core files (including `data-table-context.tsx` via the `DataTableProvider` / `DataTableContext` sections, and `data-table-virtualized-dnd-structure.tsx` via the DnD examples).
- `/niko-table/overview/filters/` — already covers all 21 filter files.
- `/niko-table/overview/hooks/` — already covers all 4 hooks.

README is unaffected — it only lists directory structure with brief descriptions, not individual files.

## Verification

- `pnpm astro-check` clean (0 errors / 0 warnings / 4 pre-existing hints).
- `pnpm astro build` produces all 39 pages including `/changelog/`, `/getting-started/manual-installation/`, `/niko-table/overview/components/`, and `/niko-table/overview/lib/` without error.
- Branched off `main` so the diff is purely doc additions and doesn't carry any in-flight code work from `fix/virtualized-row-measurement`.

## Test plan

- [ ] Open `/getting-started/manual-installation/` — project-structure tree matches `find src/components/niko-table -type f`.
- [ ] Open `/niko-table/overview/lib/` — find sections for `buildFacetedOptions` and `filter-rows.ts`.
- [ ] Open `/niko-table/overview/components/` — find a "Column Header Internal Helpers" section listing all 10 column-* helpers with working Source Code links.