### PR TITLE
fix(niko-table): drop rAF coalescing in scroll handler for iOS

### DIFF
--- a/src/components/niko-table/lib/create-scroll-handler.ts
+++ b/src/components/niko-table/lib/create-scroll-handler.ts
@@ -43,29 +43,26 @@ export function createScrollHandler({
   scrollThreshold?: number
 }): (event: Event) => void {
   /**
-   * PERFORMANCE: rAF-coalesced dispatch + edge-transition gating.
+   * Edge-transition gating only — no rAF coalescing.
    *
-   * WHY: Scroll fires up to ~120 events/sec on high-refresh displays, and
-   * `onScrolledTop` / `onScrolledBottom` previously fired on EVERY event
-   * while sitting at the edge — pinning at the bottom while data streamed
-   * in would re-fire `onScrolledBottom` dozens of times per second.
+   * Edge gating: `onScrolledTop` / `onScrolledBottom` previously fired on
+   * EVERY scroll event while sitting at the edge — pinning at the bottom
+   * while data streamed in re-fired `onScrolledBottom` dozens of times per
+   * second. Tracking previous edge state limits firing to the leading edge
+   * (false→true) and is the actual source of the perf win.
    *
-   * IMPACT: One callback dispatch per frame instead of per scroll event;
-   * top/bottom callbacks fire only on the leading edge (false→true).
-   *
-   * WHAT: Stash the latest scroll target each event, schedule a rAF if
-   * none pending; the rAF reads the (current) scroll metrics and dispatches.
-   * Track previous edge state so re-firing is suppressed.
+   * No rAF: iOS Safari pauses `requestAnimationFrame` during momentum
+   * scroll, which delayed edge callbacks until the finger lifted and
+   * momentum settled — broke infinite-scroll triggering on touch.
+   * Synchronous dispatch matches what ag-grid does (rAF is reserved for
+   * DOM writes, not consumer callbacks); the math is cheap and edge
+   * gating already prevents redundant consumer renders.
    */
   let prevAtTop = false
   let prevAtBottom = false
-  let rafId: number | null = null
-  let pending: HTMLDivElement | null = null
 
-  const dispatch = () => {
-    rafId = null
-    const element = pending
-    pending = null
+  return (event: Event) => {
+    const element = event.currentTarget as HTMLDivElement | null
     if (!element) return
 
     const { scrollHeight, scrollTop, clientHeight } = element
@@ -86,21 +83,10 @@ export function createScrollHandler({
       percentage,
     })
 
-    // Edge transition: only fire on false→true. Pinned at top/bottom
-    // does not re-fire.
     if (isTop && !prevAtTop) onScrolledTop?.()
     if (isBottom && !prevAtBottom) onScrolledBottom?.()
 
     prevAtTop = isTop
     prevAtBottom = isBottom
-  }
-
-  return (event: Event) => {
-    pending = event.currentTarget as HTMLDivElement
-    if (rafId !== null) return
-    rafId =
-      typeof requestAnimationFrame !== "undefined"
-        ? requestAnimationFrame(dispatch)
-        : (setTimeout(dispatch, 16) as unknown as number)
   }
 }

--- a/src/components/niko-table/lib/create-scroll-handler.ts
+++ b/src/components/niko-table/lib/create-scroll-handler.ts
@@ -54,9 +54,10 @@ export function createScrollHandler({
    * No rAF: iOS Safari pauses `requestAnimationFrame` during momentum
    * scroll, which delayed edge callbacks until the finger lifted and
    * momentum settled — broke infinite-scroll triggering on touch.
-   * Synchronous dispatch matches what ag-grid does (rAF is reserved for
-   * DOM writes, not consumer callbacks); the math is cheap and edge
-   * gating already prevents redundant consumer renders.
+   * Dispatch synchronously instead; the scroll math is cheap and edge
+   * gating already prevents redundant consumer renders. rAF is better
+   * reserved for DOM writes (row virtualization translateY), not
+   * consumer callbacks.
    */
   let prevAtTop = false
   let prevAtBottom = false


### PR DESCRIPTION
## Summary

- iOS Safari pauses `requestAnimationFrame` during momentum scroll, which delayed `onScrolledTop` / `onScrolledBottom` until the finger lifted and momentum settled — broke infinite-scroll triggering on touch.
- Edge-transition gating (`!prevAtBottom`) already prevents the per-event re-fires that motivated the rAF in the first place, and the scroll math is cheap (3 reads + a divide).
- Dispatch synchronously now; rAF is better reserved for DOM writes (row virtualization translateY), not consumer callbacks.

## Test plan

- [ ] Verify infinite-scroll triggers correctly on iOS Safari mid-momentum (not only after the finger lifts)
- [ ] Verify `onScrolledBottom` still fires only on the leading edge (false→true), not every scroll event while pinned at the bottom
- [ ] Smoke-test desktop scrolling on the four bodies (regular, virtualized, virtualized-DnD ×2)