### PR TITLE
fix(code-preview): keep code tab mounted so EC copy button works

### DIFF
--- a/src/components/markdown/code-preview/_code-preview-internal.tsx
+++ b/src/components/markdown/code-preview/_code-preview-internal.tsx
@@ -80,7 +80,11 @@ export function CodePreviewInternal({
               <Component />
             </Suspense>
           </TabsContent>
-          <TabsContent value="code" className="h-full">
+          <TabsContent
+            value="code"
+            forceMount
+            className="h-full data-[state=inactive]:hidden"
+          >
             {children}
           </TabsContent>
         </CardContent>


### PR DESCRIPTION
## Summary

- The Expressive Code copy button on `<CodePreview>` blocks did not copy when clicked.
- EC attaches its click handler via an initial `document.querySelectorAll(".expressive-code .copy button")` scan plus a `MutationObserver` on `document.body`. Inside Radix Tabs, the `code` panel is unmounted until selected (Radix wraps `TabsContent` in `<Presence present={forceMount || isSelected}>`), so the button isn't in the DOM during the initial scan, and the slot's HTML reinjection on mount can race with the observer — leaving clicks unhandled.
- Fix: pass `forceMount` to `<TabsContent value="code">` and hide the panel with `data-[state=inactive]:hidden` so the button is always mounted and EC's first scan finds it.

## Test plan

- [ ] Hard-refresh a docs page with a `<CodePreview>` (e.g. the All-Features example).
- [ ] Click the **Code** tab.
- [ ] Hover the code, click the copy icon — verify the "Copied!" feedback appears and the clipboard contains the source.
- [ ] Switch back to **Preview** and confirm the demo still renders correctly (no double-mount / regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)