### PR TITLE
fix(docs): inject Expressive Code styles on homepage

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -18,6 +18,10 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 
 Just like Shadcn, Niko Table is **not a component library**. Instead, it's a comprehensive **DataTable component** that you copy into your project and customize to your needs. Built with **TanStack Table** and **Shadcn UI**, it provides enterprise-grade features while remaining fully under your control.
 
+```bash
+npx shadcn@latest add https://niko-table.com/r/data-table.json
+```
+
 ## Live Demo
 
 See ALL features in action with this comprehensive example:


### PR DESCRIPTION
## Summary
- Live Demo's Code tab on `/` rendered without syntax highlighting because Starlight only emits the Expressive Code stylesheet on pages with fenced code blocks at the MDX level.
- `<Code>` used inside `CodePreview.astro` isn't seen by that scan, so `index.mdx` (which had zero fences) never got `ec.*.css`.
- Added a fenced install snippet above `## Live Demo` — same pattern other doc pages use (Basic Table etc.) — which triggers Starlight to inject the EC stylesheet for the page.

## Test plan
- [x] `npm run dev` and confirm `/_astro/ec.*.css` is now linked on `/`
- [ ] Visually verify Live Demo Code tab shows syntax-highlighted TSX matching Basic Table

🤖 Generated with [Claude Code](https://claude.com/claude-code)