### PR TITLE
docs(examples): add unique lead paragraph to every example page

### DIFF
--- a/src/content/docs/examples/advanced-inline-table.mdx
+++ b/src/content/docs/examples/advanced-inline-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Build filter inputs — selects, sliders, date pickers — directly next to the search bar instead of hiding them behind a popover. Useful when filter discoverability matters more than a minimal toolbar, like internal dashboards where users live in the filters all day.
+
 <CodePreview demo="niko-table/advanced-inline" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/advanced-nuqs-table.mdx
+++ b/src/content/docs/examples/advanced-nuqs-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+A worked example of pushing every piece of filter, sort, and pagination state into the URL via [nuqs](https://nuqs.dev/), so a complex filtered view can be copy-pasted into a teammate's browser and look identical. Pairs the rule-builder filter UI with shareable, bookmarkable links — refresh-safe and back-button-friendly.
+
 <CodePreview demo="niko-table/advanced-nuqs-state" />
 
 ## Introduction

--- a/src/content/docs/examples/advanced-table.mdx
+++ b/src/content/docs/examples/advanced-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Composes `DataTableFilterMenu` and `DataTableSortMenu` into a query-builder UX: users stack multiple typed filter rules (text, number, date, faceted) and combine them with AND/OR. State stays local — pair it with the Advanced Nuqs Table if you also need URL persistence.
+
 <CodePreview demo="niko-table/advanced" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/aside-table.mdx
+++ b/src/content/docs/examples/aside-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Mounts left and/or right panels that share the layout with the table so contextual chrome — filter trees, row detail, summary stats — doesn't compete with the data view for horizontal space. The panels are regular slots: put whatever React you want inside.
+
 <CodePreview demo="niko-table/aside" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/basic-table.mdx
+++ b/src/content/docs/examples/basic-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+A pragmatic starting point: pagination via `DataTablePagination`, per-column sort via `DataTableColumnSort`, and show/hide columns via `DataTableViewMenu`. Most app tables ship with just these three add-ons and never need anything else.
+
 <CodePreview demo="niko-table/basic" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/column-dnd-table.mdx
+++ b/src/content/docs/examples/column-dnd-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Drag column headers to reorder them, wired through `DataTableColumnDndProvider` on top of `@dnd-kit`. Unlike row DnD, column DnD is safe to combine with sorting, filtering, and virtualization — the user's column order is independent of the row model.
+
 ## Overview
 
 <CodePreview demo="niko-table/column-dnd" />

--- a/src/content/docs/examples/column-pinning-table.mdx
+++ b/src/content/docs/examples/column-pinning-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Pin one or more columns to the left or right edge so they stay anchored during horizontal scroll — handy for identifier columns (Order ID, Name) on the left and action columns (menu, edit) on the right. Sticky positioning and z-index layering are handled by the core; you just declare which columns pin and where.
+
 <CodePreview demo="niko-table/column-pinning" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/faceted-filter-table.mdx
+++ b/src/content/docs/examples/faceted-filter-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Renders inline filter chips with live counts (e.g. "Status: Active 12") next to the search bar, so users see at a glance which values exist before they filter. Built on `DataTableFacetedFilter`, which reads option counts directly from the current row model.
+
 <CodePreview demo="niko-table/faceted" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/infinite-scroll-table.mdx
+++ b/src/content/docs/examples/infinite-scroll-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Loads more rows as the user reaches the bottom of the scroll container, calling your `loadMore` handler whenever an `IntersectionObserver` sentinel becomes visible. **Heads up**: every loaded row stays in the DOM — see the caution below for when to reach for the virtualized variant instead.
+
 <CodePreview demo="niko-table/infinite-scroll-table" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/infinite-scroll-virtualized-table.mdx
+++ b/src/content/docs/examples/infinite-scroll-virtualized-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Pairs `@tanstack/react-virtual` with an `IntersectionObserver` sentinel: only on-screen rows render to the DOM, and a new page is fetched as you approach the end. Memory and frame time stay constant regardless of how many pages you've loaded — the right pick for any paginated API that can grow past a few hundred rows.
+
 <CodePreview demo="niko-table/infinite-scroll-virtualized-table" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/inline-edit-table.mdx
+++ b/src/content/docs/examples/inline-edit-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Demonstrates the `getRowMemoKey` escape hatch — Niko Table wraps every body row in `React.memo` for perf, but inline-edit drafts and validation errors live outside row props, so memo'd rows wouldn't otherwise re-render. Returning a string that encodes each row's draft + error state tells `React.memo` exactly when to allow the re-render, and exactly when to stay frozen.
+
 <CodePreview demo="niko-table/inline-edit" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/row-dnd-table.mdx
+++ b/src/content/docs/examples/row-dnd-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Reorder rows via drag-and-drop using `DataTableRowDndProvider` and a dedicated drag-handle column. **Important constraint**: do not combine row DnD with sorting or filtering — the user's manual order will fight whatever the table is computing, so disable those add-ons on a DnD table.
+
 ## Overview
 
 <CodePreview demo="niko-table/row-dnd" />

--- a/src/content/docs/examples/row-expansion-table.mdx
+++ b/src/content/docs/examples/row-expansion-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Attach arbitrary React — a sub-table, charts, a key-value detail block — to each row and reveal it inline behind a chevron toggle. Cheaper than a side panel or modal when users frequently jump between row detail and the list view, because nothing leaves the page.
+
 <CodePreview demo="niko-table/row-expansion" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/row-selection-table.mdx
+++ b/src/content/docs/examples/row-selection-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Adds a checkbox column wired to the table's `rowSelection` state, with header-row "select all" plus the indeterminate state for partial selection. Pair it with `DataTableSelectionBar` to surface bulk actions — export, delete, update — only when at least one row is checked.
+
 <CodePreview demo="niko-table/row-selection" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/search-table.mdx
+++ b/src/content/docs/examples/search-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Wires `DataTableSearchFilter` to a single input that fuzzy-matches across every visible column at once, using TanStack Table's built-in `globalFilter`. A drop-in for any table where users mostly want a "just find this thing" affordance and don't need per-column filter controls.
+
 <CodePreview demo="niko-table/search" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/server-side-nuqs-table.mdx
+++ b/src/content/docs/examples/server-side-nuqs-table.mdx
@@ -6,6 +6,8 @@ description: Server-side pagination, sorting, and filtering with TanStack Query 
 import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Combines TanStack Query (data fetching, caching, request dedup) with [nuqs](https://nuqs.dev/) URL state, so the URL itself becomes the cache key — share a link, and the recipient hits the same cached response without a refetch. The right pick for paginated APIs where you also want bookmarkable filtered views.
+
 <CodePreview demo="niko-table/server-side-nuqs-state" />
 
 ## Introduction

--- a/src/content/docs/examples/server-side-table.mdx
+++ b/src/content/docs/examples/server-side-table.mdx
@@ -6,6 +6,8 @@ description: Server-side pagination, sorting, and filtering with TanStack Query 
 import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Hands pagination, sorting, and filtering off to your API and uses TanStack Query for caching, background revalidation, and request dedup. Table state lives in `useState` only — a refresh resets filters; use the Nuqs variant if you also need URL persistence.
+
 <CodePreview demo="niko-table/server-side-state" />
 
 ## Introduction

--- a/src/content/docs/examples/simple-table.mdx
+++ b/src/content/docs/examples/simple-table.mdx
@@ -6,6 +6,8 @@ description: A basic data table with no pagination - perfect for small datasets.
 import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+The smallest possible install: just `@niko-table/data-table`, no add-ons. Renders an accessible `<thead>`/`<tbody>` and stops there — no pagination, no sort, no filters. Reach for it when the dataset is short and static, and ceremony would just get in the way.
+
 <CodePreview demo="niko-table/simple" />
 
 ## Introduction

--- a/src/content/docs/examples/tree-table.mdx
+++ b/src/content/docs/examples/tree-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Renders nested row models (`subRows`) with collapsible parents and optional cascading selection — checking a parent flips every descendant, and partial child selection bubbles up as indeterminate. Backed by TanStack Table's expanded-row model, so there's no recursive code in your column defs.
+
 <CodePreview demo="niko-table/tree-table" />
 
 <CollapsiblePreview>

--- a/src/content/docs/examples/virtualization-table.mdx
+++ b/src/content/docs/examples/virtualization-table.mdx
@@ -7,6 +7,8 @@ import CodePreview from "@/components/markdown/code-preview/code-preview.astro"
 import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 
+Uses `@tanstack/react-virtual` to keep only the rows in the viewport mounted in the DOM, so render cost stays flat past 10k rows. Drop-in swap: replace `DataTableBody` with `DataTableVirtualizedBody` and provide a row-height estimator — every other Niko Table add-on still works on top.
+
 <CodePreview demo="niko-table/virtualization-table" />
 
 <CollapsiblePreview>


### PR DESCRIPTION
Each /examples page previously opened with the same template (imports → CodePreview → CollapsiblePreview → "## Introduction"), which Google flagged as templated content (Crawled - currently not indexed). Add a distinct 1-2 sentence lead above the demo on each page so the visible above-the-fold prose differs across the 20 example pages.