### PR TITLE
feat(slider-filter): add live range match count in popover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Faceted filter** — caller-supplied options no longer narrowed to current row set; caller is the source of truth. `TableColumnFacetedFilterMenu` decouples `limitToFilteredRows` from the `multiple` default for caller options.
 - **`TableRangeFilter`** — `[min, max]` memo depends on faceted scalars; `formatValue` no longer locale-formats numbers.
 - **`TableSliderFilter` clear button** — always `stopPropagation()` (SVG/icon clicks no longer reopen the popover).
+- **`TableSliderFilter` popover range feedback** — shows a live match-count badge for the active range (computed from faceted rows in current cross-filter context) and uses fluid min/max inputs for better narrow-layout usability.
 - **`TableSearchFilter` `debounceMs`** — pending timer cancelled on `!debounceEnabled` early return and before out-of-band state resets, preventing stale flushes.
 - **CSV export** — plain objects JSON-encoded instead of serializing as `[object Object]`.
 - **Virtualized bodies** — expanded-row height re-measured on toggle/column-layout change without losing `useSortable` registration; `data-index` uses `virtualRow.index`; click delegation via stable `data-row-id`.

--- a/src/components/niko-table/filters/table-slider-filter.tsx
+++ b/src/components/niko-table/filters/table-slider-filter.tsx
@@ -170,6 +170,24 @@ export function TableSliderFilter<TData>({
     return value.toLocaleString(undefined, { maximumFractionDigits: 0 })
   }, [])
 
+  // Match count: rows that fall inside the currently-selected range,
+  // sourced from the faceted row model so the number reflects "matches
+  // before this filter is applied" within the current cross-filter
+  // context. Renders inside the popover next to the label so the user
+  // sees the hit count for the active range as they drag the slider.
+  const facetedRows = column.getFacetedRowModel().rows
+  const matchCount = React.useMemo(() => {
+    const [filterMin, filterMax] = range
+    let count = 0
+    for (const row of facetedRows) {
+      const raw = row.getValue(column.id)
+      const value = typeof raw === "number" ? raw : Number(raw)
+      if (!Number.isFinite(value)) continue
+      if (value >= filterMin && value <= filterMax) count += 1
+    }
+    return count
+  }, [range, facetedRows, column.id])
+
   const applyFilterValue = React.useCallback(
     (value: [number, number] | undefined) => {
       column.setFilterValue(value)
@@ -254,14 +272,19 @@ export function TableSliderFilter<TData>({
       </PopoverTrigger>
       <PopoverContent align="start" className="flex w-auto flex-col gap-4">
         <div className="flex flex-col gap-3">
-          <p className="leading-none font-medium peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
-            {label}
-          </p>
-          <div className="flex items-center gap-4">
+          <div className="flex h-5 items-center justify-between gap-2">
+            <p className="font-medium leading-5 peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+              {label}
+            </p>
+            <span className="bg-secondary text-secondary-foreground inline-flex h-5 items-center justify-center rounded-sm px-1.5 text-xs leading-none font-normal tabular-nums">
+              {matchCount}
+            </span>
+          </div>
+          <div className="flex items-center gap-2">
             <Label htmlFor={`${id}-from`} className="sr-only">
               From
             </Label>
-            <div className="relative">
+            <div className="relative flex-1">
               <Input
                 key={`${id}-from-${range[0]}`}
                 id={`${id}-from`}
@@ -278,7 +301,7 @@ export function TableSliderFilter<TData>({
                 onChange={event =>
                   onRangeValueChange(String(event.target.value), true)
                 }
-                className={cn("h-8 w-24", unit && "pr-8")}
+                className={cn("h-8 w-full", unit && "pr-8")}
               />
               {unit && (
                 <span className="absolute top-0 right-0 bottom-0 mt-0.5 mr-0.5 flex h-7 items-center rounded-r-md bg-accent px-2 text-sm text-muted-foreground">
@@ -289,7 +312,7 @@ export function TableSliderFilter<TData>({
             <Label htmlFor={`${id}-to`} className="sr-only">
               to
             </Label>
-            <div className="relative">
+            <div className="relative flex-1">
               <Input
                 key={`${id}-to-${range[1]}`}
                 id={`${id}-to`}
@@ -306,7 +329,7 @@ export function TableSliderFilter<TData>({
                 onChange={event =>
                   onRangeValueChange(String(event.target.value))
                 }
-                className={cn("h-8 w-24", unit && "pr-8")}
+                className={cn("h-8 w-full", unit && "pr-8")}
               />
               {unit && (
                 <span className="absolute top-0 right-0 bottom-0 mt-0.5 mr-0.5 flex h-7 items-center rounded-r-md bg-accent px-2 text-sm text-muted-foreground">


### PR DESCRIPTION
## Summary
- add live match-count badge in TableSliderFilter popover for current selected range
- compute count from faceted row model so it reflects current cross-filter context
- improve popover range inputs to use fluid width for tighter layouts
- update changelog entry under Unreleased/Fixes

## Files
- src/components/niko-table/filters/table-slider-filter.tsx
- CHANGELOG.md
