### PR TITLE
docs: align key features with composability and honest claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Niko Table is built around the following principles:
 - **Composable Column Headers** — Build custom column headers with sort, filter, pin, and hide controls
 - **Empty States** — Composable empty state with filtered/unfiltered messaging
 - **Type-Safe** — Full TypeScript support with comprehensive type definitions
-- **Accessible** — WCAG 2.1 compliant with keyboard navigation and screen reader support
+- **Accessible** — Radix UI primitives, ARIA in filters/menus, keyboard shortcuts; jsx-a11y in this repo (verify in your app for full conformance)
 - **Responsive** — Mobile-friendly design with touch-friendly controls
 
 ## Quick Start

--- a/src/content/docs/getting-started/introduction.mdx
+++ b/src/content/docs/getting-started/introduction.mdx
@@ -47,18 +47,21 @@ Since you own the code, you can:
 
 ### ♿ Accessible by Default
 
-- WCAG 2.1 compliant
-- Full keyboard navigation
-- Screen reader support
-- Semantic HTML
-- ARIA labels and roles
+Built on **Radix UI** primitives with semantic table markup where possible:
 
-### 📱 Mobile-Friendly
+- Keyboard support in sort/filter menus and toolbar controls
+- ARIA labels on filter triggers, sliders, and clear actions
+- Screen-reader-friendly patterns via Shadcn/Radix components
+- **jsx-a11y** lint rules on docs and source
 
-- Responsive design
-- Touch-friendly controls
-- Mobile-optimized filters
-- Collapsible sidebars
+We do not claim third-party WCAG certification; treat complex tables (virtualization, DnD, pinning) like any custom UI and verify with your own accessibility checklist.
+
+### 📱 Responsive layout
+
+- `DataTable` uses a full-width **`overflow-auto`** scroll region for wide column sets on small screens
+- Popovers and filter panels respect available viewport width
+- Optional **`DataTableAside`** for a collapsible detail panel (see [Aside Table](/examples/aside-table/))
+- Toolbars are plain flex layouts — wrap or hide filters on mobile in your app as needed
 
 ## How It Works
 
@@ -112,6 +115,26 @@ Build tables by composing components - start simple and add features as needed:
 </DataTableRoot>
 ```
 
+## Composability map
+
+Niko Table is **mix-and-match**: install only the registry items you need, render only the children you want, and swap body strategies without rewriting column defs.
+
+| Layer               | What you choose                                                                             | Notes                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------ |
+| **Root**            | `DataTableRoot`                                                                             | Required. Optional controlled `state`, `config` overrides, `getRowId` for selection/DnD/expansion |
+| **Toolbar**         | `DataTableToolbarSection` + any of search, faceted, filter menu, view menu, clear           | Omitted entirely for minimal tables                                                               |
+| **Table shell**     | `DataTable` with `height` / `max-h-*` when virtualizing                                     | Virtualizer needs a bounded scroll container                                                      |
+| **Header / body**   | Regular: `DataTableHeader` + `DataTableBody`                                                | Default path                                                                                      |
+|                     | Virtualized: `DataTableVirtualizedHeader` + `DataTableVirtualizedBody`                      | [10k+ rows](/examples/virtualization-table/)                                                      |
+|                     | Row DnD: `DataTableRowDndProvider` (outside table) + `DataTableDndBody`                     | Do **not** combine with sort/filter                                                               |
+|                     | Column DnD                                                                                  | `DataTableColumnDndProvider` + draggable headers/cells                                            | Safe with other features |
+| **Loading / empty** | `DataTableSkeleton`, `DataTableEmptyBody` or composable empty pieces                        | Siblings inside the body                                                                          |
+| **Footer**          | `DataTablePagination`, `DataTableSelectionBar`                                              | Optional                                                                                          |
+| **Row actions**     | One `RowMenu*` component + `useDataTableRow` in kebab **and** `DataTableRowContextMenuSlot` | [Row context menu](/examples/row-context-menu-table/)                                             |
+| **Escape hatch**    | `Table*` filters with your own `table` instance                                             | Custom layouts without context                                                                    |
+
+`DataTableRoot` runs **feature detection** on children (`detectFeaturesFromChildren`) so pagination, filtering, and sorting turn on when you add the matching components — you rarely hand-roll a giant config object.
+
 ## What's Included
 
 This DataTable provides you with:
@@ -120,7 +143,7 @@ This DataTable provides you with:
 - **Composable components** - Build complex UIs from simple, reusable pieces
 - **State management** - Context-based state sharing with hook-based flexibility
 - **Performance optimization** - Virtual scrolling, memoization, and efficient rendering
-- **Accessibility** - WCAG 2.1 compliant with full keyboard navigation and screen reader support
+- **Accessibility** - Radix primitives, keyboard-friendly filters/menus, jsx-a11y linting (verify end-to-end in your app)
 - **TypeScript** - Fully typed with comprehensive type definitions
 
 ## Philosophy

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -62,12 +62,12 @@ This demo showcases every feature:
 ## Key Features
 
 - **Type-safe** - Full TypeScript support
-- **Accessible** - WCAG 2.1 compliant with keyboard navigation
-- **Responsive** - Mobile-friendly design
+- **Accessible** - Radix UI primitives, ARIA labels in filters/menus, keyboard shortcuts; linted with jsx-a11y
+- **Responsive** - Full-width scroll container (`overflow-auto`); touch-friendly Radix controls; stack toolbars as needed on small screens
 - **Customizable** - Full source code access
-- **Composable** - Mix and match components
-- **Performance** - Virtual scrolling for 10,000+ rows
-- **State Management** - Context-based with hook flexibility
+- **Composable** - Mix and match components (install only the registry pieces you need)
+- **Performance** - Virtual scrolling for 10,000+ client-side rows (fixed-height scroll container)
+- **State Management** - Context-based `useDataTable()` with controlled state and optional URL sync (nuqs)
 
 ## Built With
 

--- a/src/content/docs/niko-table/overview/config.mdx
+++ b/src/content/docs/niko-table/overview/config.mdx
@@ -72,7 +72,7 @@ Automatic feature detection from component tree to enable/disable table features
 Recursively searches for components and aggregates feature requirements. Automatically detects which features should be enabled based on the components used in the table.
 
 ```tsx showLineNumbers
-import { detectFeaturesFromChildren } from "@/components/niko-table/config"
+import { detectFeaturesFromChildren } from "@/components/niko-table/config/feature-detection"
 
 const requirements = detectFeaturesFromChildren(children, columns)
 // Returns: { enableFilters: true, enablePagination: true, ... }
@@ -120,7 +120,7 @@ Caching is only enabled on the client-side to prevent SSR/CSR hydration mismatch
 Register a component's feature requirements. Allows third-party components to declare their needs.
 
 ```tsx showLineNumbers
-import { registerComponentFeatures } from "@/components/niko-table/config"
+import { registerComponentFeatures } from "@/components/niko-table/config/feature-detection"
 
 registerComponentFeatures("MyCustomFilter", {
   enableFilters: true,
@@ -139,7 +139,7 @@ registerComponentFeatures("MyCustomFilter", {
 Get all registered components and their features (for debugging).
 
 ```tsx showLineNumbers
-import { getRegisteredComponents } from "@/components/niko-table/config"
+import { getRegisteredComponents } from "@/components/niko-table/config/feature-detection"
 
 const registered = getRegisteredComponents()
 // Returns: { DataTablePagination: { enablePagination: true }, ... }

--- a/src/registry/new-york/examples/niko-table/pagination-loading.tsx
+++ b/src/registry/new-york/examples/niko-table/pagination-loading.tsx
@@ -134,8 +134,8 @@ const generateMockOrders = (count: number): Order[] => {
     id: `${i + 1}`,
     orderNumber: `ORD-${1000 + i}`,
     customer: customers[i % customers.length],
-    amount: Math.random() * 1000 + 50,
-    status: statuses[Math.floor(Math.random() * statuses.length)],
+    amount: ((i * 17) % 950) + 50,
+    status: statuses[i % statuses.length],
     date: new Date(2024, 0, i + 1).toLocaleDateString(),
   }))
 }

--- a/src/registry/new-york/examples/niko-table/server-side-nuqs-state.tsx
+++ b/src/registry/new-york/examples/niko-table/server-side-nuqs-state.tsx
@@ -690,8 +690,8 @@ function fetchProducts(
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       try {
-        // Simulate occasional errors (5% chance)
-        if (Math.random() < 0.05) {
+        // Simulate occasional errors (~5% of page indices, deterministic for demos)
+        if (params.page > 0 && params.page % 20 === 0) {
           reject(new Error("Server error: Failed to fetch products"))
           return
         }
@@ -1038,8 +1038,7 @@ function InlineFilterToolbar({
  */
 function normalizeFiltersWithUniqueIds<TData>(
   filters: (
-    | Omit<ExtendedColumnFilter<TData>, "filterId">
-    | ExtendedColumnFilter<TData>
+    Omit<ExtendedColumnFilter<TData>, "filterId"> | ExtendedColumnFilter<TData>
   )[],
 ): ExtendedColumnFilter<TData>[] {
   // Quick check: if all filters already have unique filterIds, return as-is
@@ -1177,8 +1176,7 @@ function ServerSideStateTableContent() {
 
   // Get filter mode from URL
   const filterMode = (urlParams.filterMode || "standard") as
-    | "standard"
-    | "inline"
+    "standard" | "inline"
 
   // Global filter from URL - handle both search string and OR filters
   const globalFilter = useMemo(() => {

--- a/src/registry/new-york/examples/niko-table/server-side-state.tsx
+++ b/src/registry/new-york/examples/niko-table/server-side-state.tsx
@@ -627,8 +627,8 @@ function fetchProducts(
   return new Promise((resolve, reject) => {
     setTimeout(() => {
       try {
-        // Simulate occasional errors (5% chance)
-        if (Math.random() < 0.05) {
+        // Simulate occasional errors (~5% of page indices, deterministic for demos)
+        if (params.page > 0 && params.page % 20 === 0) {
           reject(new Error("Server error: Failed to fetch products"))
           return
         }
@@ -953,8 +953,7 @@ function InlineFilterToolbar({
  */
 function normalizeFiltersWithUniqueIds<TData>(
   filters: (
-    | Omit<ExtendedColumnFilter<TData>, "filterId">
-    | ExtendedColumnFilter<TData>
+    Omit<ExtendedColumnFilter<TData>, "filterId"> | ExtendedColumnFilter<TData>
   )[],
 ): ExtendedColumnFilter<TData>[] {
   // Quick check: if all filters already have unique filterIds, return as-is

--- a/src/registry/new-york/examples/niko-table/virtualization-table-state.tsx
+++ b/src/registry/new-york/examples/niko-table/virtualization-table-state.tsx
@@ -66,48 +66,45 @@ interface Product {
   releaseDate: Date
 }
 
-// Generate large dataset for virtualization demo
-const generateLargeData = (count: number): Product[] => {
-  const categories = [
-    "Electronics",
-    "Clothing",
-    "Food",
-    "Books",
-    "Sports",
-    "Home",
-    "Toys",
-    "Beauty",
-  ]
-  const brands = [
-    "Apple",
-    "Samsung",
-    "Nike",
-    "Adidas",
-    "Sony",
-    "LG",
-    "Dell",
-    "HP",
-  ]
+// Deterministic mock data — safe for SSR/Strict Mode (see infinite-scroll-virtualized-table.tsx).
+const CATEGORIES = [
+  "Electronics",
+  "Clothing",
+  "Food",
+  "Books",
+  "Sports",
+  "Home",
+  "Toys",
+  "Beauty",
+] as const
 
+const BRANDS = [
+  "Apple",
+  "Samsung",
+  "Nike",
+  "Adidas",
+  "Sony",
+  "LG",
+  "Dell",
+  "HP",
+] as const
+
+const generateLargeData = (count: number): Product[] => {
   return Array.from({ length: count }, (_, i) => {
-    const stock = Math.floor(Math.random() * 150)
-    const price = Math.floor(Math.random() * 500) + 10
+    const stock = (i * 37) % 150
+    const price = ((i * 13) % 490) + 10
     return {
       id: `product-${i + 1}`,
       name: `Product ${i + 1}`,
-      category: categories[Math.floor(Math.random() * categories.length)],
-      brand: brands[Math.floor(Math.random() * brands.length)],
+      category: CATEGORIES[i % CATEGORIES.length],
+      brand: BRANDS[i % BRANDS.length],
       price,
       stock,
-      rating: Math.floor(Math.random() * 5) + 1,
+      rating: ((i * 7) % 5) + 1,
       revenue: price * stock,
       status:
         stock === 0 ? "out-of-stock" : stock < 20 ? "low-stock" : "in-stock",
-      releaseDate: new Date(
-        2024,
-        Math.floor(Math.random() * 12),
-        Math.floor(Math.random() * 28) + 1,
-      ),
+      releaseDate: new Date(2024, (i * 3) % 12, ((i * 7) % 28) + 1),
     }
   })
 }

--- a/src/registry/new-york/examples/niko-table/virtualization-table.tsx
+++ b/src/registry/new-york/examples/niko-table/virtualization-table.tsx
@@ -45,48 +45,45 @@ interface Product {
   releaseDate: Date
 }
 
-// Generate large dataset for virtualization demo
-const generateLargeData = (count: number): Product[] => {
-  const categories = [
-    "Electronics",
-    "Clothing",
-    "Food",
-    "Books",
-    "Sports",
-    "Home",
-    "Toys",
-    "Beauty",
-  ]
-  const brands = [
-    "Apple",
-    "Samsung",
-    "Nike",
-    "Adidas",
-    "Sony",
-    "LG",
-    "Dell",
-    "HP",
-  ]
+// Deterministic mock data — safe for SSR/Strict Mode (see infinite-scroll-virtualized-table.tsx).
+const CATEGORIES = [
+  "Electronics",
+  "Clothing",
+  "Food",
+  "Books",
+  "Sports",
+  "Home",
+  "Toys",
+  "Beauty",
+] as const
 
+const BRANDS = [
+  "Apple",
+  "Samsung",
+  "Nike",
+  "Adidas",
+  "Sony",
+  "LG",
+  "Dell",
+  "HP",
+] as const
+
+const generateLargeData = (count: number): Product[] => {
   return Array.from({ length: count }, (_, i) => {
-    const stock = Math.floor(Math.random() * 150)
-    const price = Math.floor(Math.random() * 500) + 10
+    const stock = (i * 37) % 150
+    const price = ((i * 13) % 490) + 10
     return {
       id: `product-${i + 1}`,
       name: `Product ${i + 1}`,
-      category: categories[Math.floor(Math.random() * categories.length)],
-      brand: brands[Math.floor(Math.random() * brands.length)],
+      category: CATEGORIES[i % CATEGORIES.length],
+      brand: BRANDS[i % BRANDS.length],
       price,
       stock,
-      rating: Math.floor(Math.random() * 5) + 1,
+      rating: ((i * 7) % 5) + 1,
       revenue: price * stock,
       status:
         stock === 0 ? "out-of-stock" : stock < 20 ? "low-stock" : "in-stock",
-      releaseDate: new Date(
-        2024,
-        Math.floor(Math.random() * 12),
-        Math.floor(Math.random() * 28) + 1,
-      ),
+      releaseDate: new Date(2024, (i * 3) % 12, ((i * 7) % 28) + 1),
     }
   })
 }

--- a/src/registry/new-york/examples/niko-table/virtualized-column-dnd.tsx
+++ b/src/registry/new-york/examples/niko-table/virtualized-column-dnd.tsx
@@ -112,17 +112,17 @@ const generateEmployees = (count: number): Employee[] => {
   const statuses: Employee["status"][] = ["active", "on-leave", "remote"]
 
   return Array.from({ length: count }, (_, i) => {
-    const firstName = firstNames[Math.floor(Math.random() * firstNames.length)]
-    const lastName = lastNames[Math.floor(Math.random() * lastNames.length)]
+    const firstName = firstNames[i % firstNames.length]
+    const lastName = lastNames[(i * 3) % lastNames.length]
     return {
       id: `EMP-${String(i + 1).padStart(4, "0")}`,
       name: `${firstName} ${lastName}`,
       email: `${firstName.toLowerCase()}.${lastName.toLowerCase()}${i}@company.com`,
-      department: departments[Math.floor(Math.random() * departments.length)],
-      role: roles[Math.floor(Math.random() * roles.length)],
-      location: locations[Math.floor(Math.random() * locations.length)],
-      status: statuses[Math.floor(Math.random() * statuses.length)],
-      salary: Math.floor(Math.random() * 100000) + 50000,
+      department: departments[i % departments.length],
+      role: roles[(i * 5) % roles.length],
+      location: locations[(i * 7) % locations.length],
+      status: statuses[i % statuses.length],
+      salary: 50000 + ((i * 1337) % 100000),
     }
   })
 }

--- a/src/registry/new-york/examples/niko-table/virtualized-row-dnd.tsx
+++ b/src/registry/new-york/examples/niko-table/virtualized-row-dnd.tsx
@@ -80,9 +80,9 @@ const generateTasks = (count: number): Task[] => {
   return Array.from({ length: count }, (_, i) => ({
     id: `TASK-${String(i + 1).padStart(4, "0")}`,
     title: titles[i % titles.length],
-    status: statuses[Math.floor(Math.random() * statuses.length)],
-    priority: priorities[Math.floor(Math.random() * priorities.length)],
-    assignee: assignees[Math.floor(Math.random() * assignees.length)],
+    status: statuses[i % statuses.length],
+    priority: priorities[i % priorities.length],
+    assignee: assignees[i % assignees.length],
   }))
 }
 


### PR DESCRIPTION
## Summary
- Reword homepage/README/intro accessibility and responsive bullets to match what we ship (Radix + jsx-a11y), without claiming WCAG certification.
- Add a **Composability map** to Getting Started (layers, body variants, DnD rules, row menu pattern, feature detection).
- Fix `config.mdx` imports to `@/components/niko-table/config/feature-detection` (no config barrel).
- Make registry mock data **deterministic** in virtualization, DnD, pagination-loading, and server-side error demos (no `Math.random` in example data).

## Test plan
- [x] `pnpm build`
- [x] `pnpm lint` (0 errors)
- [x] No remaining `WCAG 2.1` marketing strings in repo
- [x] `Math.random` only in comments in niko-table examples


Made with [Cursor](https://cursor.com)