### PR TITLE
fix(seo): titles, schema, robots, and discovery metadata

### DIFF
--- a/astro.config.mts
+++ b/astro.config.mts
@@ -113,7 +113,7 @@ export default defineConfig({
           },
         },
       ],
-      title: "Niko Table - Nobody's table, everyone's solution",
+      title: "Niko Table",
       editLink: {
         baseUrl: `${GITHUB_REPO_URL}/tree/main`,
       },

--- a/public/_redirects
+++ b/public/_redirects
@@ -36,3 +36,11 @@
 /niko-table/server-side-table/ /examples/server-side-table/ 301
 /niko-table/server-side-nuqs-table /examples/server-side-nuqs-table/ 301
 /niko-table/server-side-nuqs-table/ /examples/server-side-nuqs-table/ 301
+/niko-table/row-context-menu-table /examples/row-context-menu-table/ 301
+/niko-table/row-context-menu-table/ /examples/row-context-menu-table/ 301
+/niko-table/infinite-scroll-table /examples/infinite-scroll-table/ 301
+/niko-table/infinite-scroll-table/ /examples/infinite-scroll-table/ 301
+/niko-table/infinite-scroll-virtualized-table /examples/infinite-scroll-virtualized-table/ 301
+/niko-table/infinite-scroll-virtualized-table/ /examples/infinite-scroll-virtualized-table/ 301
+/niko-table/inline-edit-table /examples/inline-edit-table/ 301
+/niko-table/inline-edit-table/ /examples/inline-edit-table/ 301

--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -1,21 +1,23 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
-  "icons": [
-    {
-      "src": "/web-app-manifest-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/web-app-manifest-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
-    }
-  ],
+  "name": "Niko Table",
+  "short_name": "Niko Table",
+  "description": "Shadcn-compatible React data table registry built with TanStack Table.",
+  "start_url": "/",
+  "display": "browser",
   "theme_color": "#000000",
   "background_color": "#000000",
-  "display": "standalone"
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/favicon.ico",
+      "sizes": "48x48",
+      "type": "image/x-icon",
+      "purpose": "any"
+    }
+  ]
 }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,12 +1,14 @@
 # Niko Table
 
-> Niko Table is a composable, shadcn-compatible data table component registry built with TanStack Table, React, and Tailwind CSS. It follows an open-code philosophy — install components into your project and own the code. Features include sorting, filtering, pagination, row selection, row expansion, column pinning, drag-and-drop (row and column), virtualization, server-side data, and URL state management. AI-Ready by design.
+> Niko Table is a composable, shadcn-compatible data table component registry built with TanStack Table, React, and Tailwind CSS. It follows an open-code philosophy — install components into your project and own the code. Features include sorting, filtering, pagination, row selection, row expansion, row context menus, column pinning, drag-and-drop (row and column), virtualization, infinite scroll, server-side data, and URL state management (nuqs).
 
 ## Getting Started
 
-- [Introduction](https://niko-table.com/getting-started/introduction): Overview, quick start, and installation instructions.
+- [Introduction](https://niko-table.com/getting-started/introduction): Architecture, composability, and progressive complexity.
 - [Installation](https://niko-table.com/getting-started/installation): CLI-based installation using the shadcn registry.
 - [Manual Installation](https://niko-table.com/getting-started/manual-installation): Step-by-step manual setup without the CLI.
+- [Components catalog](https://niko-table.com/getting-started/components): Registry item list and install commands.
+- [Skills (AI)](https://niko-table.com/getting-started/skills): Agent skill for Niko Table patterns.
 
 ## API Reference
 
@@ -30,6 +32,8 @@
 
 - [Row Selection Table](https://niko-table.com/examples/row-selection-table): Checkbox-based row selection with bulk actions.
 - [Row Expansion Table](https://niko-table.com/examples/row-expansion-table): Expandable rows with custom content.
+- [Row Context Menu Table](https://niko-table.com/examples/row-context-menu-table): Shared kebab and right-click row actions (composable RowMenu* API).
+- [Inline Edit Table](https://niko-table.com/examples/inline-edit-table): Editable cells in the table body.
 - [Column Pinning Table](https://niko-table.com/examples/column-pinning-table): Pin columns to left or right edges.
 - [Tree Table](https://niko-table.com/examples/tree-table): Hierarchical tree data with expand/collapse.
 
@@ -41,7 +45,9 @@
 ### Layout & Presentation
 
 - [Aside Table](https://niko-table.com/examples/aside-table): Table with a collapsible sidebar panel.
-- [Virtualization Table](https://niko-table.com/examples/virtualization-table): Virtual scrolling for large datasets using @tanstack/react-virtual.
+- [Virtualization Table](https://niko-table.com/examples/virtualization-table): Virtual scrolling for 10,000+ rows using @tanstack/react-virtual.
+- [Infinite Scroll Table](https://niko-table.com/examples/infinite-scroll-table): Load more rows as the user scrolls.
+- [Infinite Scroll Virtualized Table](https://niko-table.com/examples/infinite-scroll-virtualized-table): Virtual scrolling plus paginated infinite loading.
 
 ### Filtering
 
@@ -66,3 +72,4 @@
 
 - [Component Overview](https://niko-table.com/niko-table/components): High-level directory of all components organized by category.
 - [DataTable Introduction](https://niko-table.com/niko-table/introduction): Deep dive into the DataTable component system and composition patterns.
+- [Changelog](https://niko-table.com/changelog): Release notes and registry updates.

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /r/
 
 Sitemap: https://niko-table.com/sitemap-index.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,21 +1,23 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
-  "icons": [
-    {
-      "src": "/web-app-manifest-192x192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/web-app-manifest-512x512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
-    }
-  ],
+  "name": "Niko Table",
+  "short_name": "Niko Table",
+  "description": "Shadcn-compatible React data table registry built with TanStack Table.",
+  "start_url": "/",
+  "display": "browser",
   "theme_color": "#000000",
   "background_color": "#000000",
-  "display": "standalone"
+  "icons": [
+    {
+      "src": "/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/favicon.ico",
+      "sizes": "48x48",
+      "type": "image/x-icon",
+      "purpose": "any"
+    }
+  ]
 }

--- a/src/components/overrides/head.astro
+++ b/src/components/overrides/head.astro
@@ -2,35 +2,54 @@
 const { head } = Astro.locals.starlightRoute
 const { title, description } = Astro.locals.starlightRoute.entry.data
 const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href
+const pathname = Astro.url.pathname
+const isHomePage = pathname === "/" || pathname === ""
+const isExamplePage = pathname.startsWith("/examples/")
+const isInstallationPage =
+  pathname.includes("/getting-started/installation") ||
+  pathname.includes("/getting-started/manual-installation")
 
 // By default, Astro renders the default favicon before the media specific favicons which results in the media specific favicons not being used.
 // This code forces the default favicon to only be used when the user has no preference for light or dark mode instead of always being used.
-const sortedHead = head.map(h => {
-  if (h.tag !== "link") return h
-  if (
-    typeof h.attrs !== "object" ||
-    typeof h.attrs.rel !== "string" ||
-    !h.attrs.rel.includes("icon") ||
-    h.attrs.media
-  ) {
+const processedHead = head
+  .map(h => {
+    if (h.tag !== "link") return h
+    if (
+      typeof h.attrs !== "object" ||
+      typeof h.attrs.rel !== "string" ||
+      !h.attrs.rel.includes("icon") ||
+      h.attrs.media
+    ) {
+      return h
+    }
+
+    return {
+      ...h,
+      attrs: { ...h.attrs, media: "(prefers-color-scheme: no-preference)" },
+    }
+  })
+  .filter(h => {
+    if (h.tag !== "link" || typeof h.attrs !== "object") return true
+    const rel = h.attrs.rel
+    return rel !== "canonical"
+  })
+  .map(h => {
+    if (h.tag !== "meta" || typeof h.attrs !== "object") return h
+    if (h.attrs.property === "og:type" && isHomePage) {
+      return { ...h, attrs: { ...h.attrs, content: "website" } }
+    }
     return h
-  }
+  })
 
-  return {
-    ...h,
-    attrs: { ...h.attrs, media: "(prefers-color-scheme: no-preference)" },
-  }
-})
-
-const isHomePage = Astro.url.pathname === "/" || Astro.url.pathname === ""
+const siteUrl = Astro.site?.href ?? "https://niko-table.com/"
 
 const websiteSchema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
   name: "Niko Table",
   description:
-    "A composable, shadcn-compatible data table component registry built with TanStack Table and React.",
-  url: Astro.site?.href ?? "https://niko-table.com",
+    "Composable, shadcn-compatible React data table components built with TanStack Table. Copy source via the registry CLI.",
+  url: siteUrl,
 }
 
 const softwareSchema = {
@@ -45,7 +64,28 @@ const softwareSchema = {
   license: "https://opensource.org/licenses/MIT",
 }
 
-const breadcrumbItems = Astro.url.pathname
+const techArticleSchema = {
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  headline: title ?? "Niko Table",
+  description: description ?? "Niko Table documentation",
+  url: canonicalUrl,
+  author: {
+    "@type": "Organization",
+    name: "Niko Table",
+    url: siteUrl,
+  },
+}
+
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: title ?? "Niko Table",
+  description: description ?? "Niko Table documentation",
+  url: canonicalUrl,
+}
+
+const breadcrumbItems = pathname
   .split("/")
   .filter(Boolean)
   .map((segment, index, arr) => ({
@@ -61,16 +101,25 @@ const breadcrumbSchema = {
   itemListElement: breadcrumbItems,
 }
 
-const jsonLd = isHomePage
-  ? JSON.stringify(websiteSchema)
-  : JSON.stringify([softwareSchema, breadcrumbSchema])
+function primarySchema() {
+  if (isHomePage) return websiteSchema
+  if (isInstallationPage) return softwareSchema
+  if (isExamplePage) return techArticleSchema
+  return webPageSchema
+}
+
+const jsonLd =
+  isHomePage || breadcrumbItems.length === 0
+    ? JSON.stringify(primarySchema())
+    : JSON.stringify([primarySchema(), breadcrumbSchema])
 ---
 
 {
-  sortedHead.map(({ tag: Tag, attrs, content }) => (
+  processedHead.map(({ tag: Tag, attrs, content }) => (
     <Tag {...attrs} set:html={content} />
   ))
 }
 
 <link rel="canonical" href={canonicalUrl} />
+<link rel="manifest" href="/site.webmanifest" />
 <script is:inline type="application/ld+json" set:html={jsonLd} />

--- a/src/content/docs/examples/virtualization-table.mdx
+++ b/src/content/docs/examples/virtualization-table.mdx
@@ -1,6 +1,6 @@
 ---
 title: Virtualization Table
-description: Handle large datasets efficiently with virtual scrolling.
+description: Virtual scrolling for 10,000+ React table rows with @tanstack/react-virtual—swap DataTableBody for DataTableVirtualizedBody in your shadcn data table.
 ---
 
 import CodePreview from "@/components/markdown/code-preview/code-preview.astro"

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: How to install and set up the DataTable component in your project.
+description: Install Niko Table with the shadcn CLI—add @niko-table/data-table and optional registry components to your React + TanStack Table project.
 ---
 
 import { Steps } from "@astrojs/starlight/components"

--- a/src/content/docs/getting-started/introduction.mdx
+++ b/src/content/docs/getting-started/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: A powerful, flexible DataTable component built with TanStack Table and Shadcn UI.
+description: Open-code React data tables for shadcn/ui—composable DataTable* components, TanStack Table state, and copy-paste registry installs.
 ---
 
 import { GITHUB_REPO_URL } from "@/data/env"

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
-title: Niko Table
-description: A powerful, flexible data table component built with TanStack Table and Shadcn UI.
+title: Shadcn-Compatible React Data Table
+description: Copy-paste TanStack Table components for React and shadcn/ui. Install sorting, filters, virtualization, and server-side patterns via the Niko Table registry.
 hero:
   tagline: Build production-ready data tables with sorting, filtering, pagination, virtualization, and more.
   actions:
@@ -56,6 +56,8 @@ This demo showcases every feature:
 - **[Basic Table](/examples/basic-table/)** - Pagination and sorting
 - **[Search Table](/examples/search-table/)** - Add global search
 - **[Faceted Filter Table](/examples/faceted-filter-table/)** - Column-specific filters
+- **[Virtualization Table](/examples/virtualization-table/)** - 10,000+ rows with virtual scrolling
+- **[Row Context Menu Table](/examples/row-context-menu-table/)** - Shared kebab and right-click actions
 - **[Advanced Table](/examples/advanced-table/)** - All features combined
 - **[Advanced Nuqs Table](/examples/advanced-nuqs-table/)** - URL state persistence
 


### PR DESCRIPTION
## Summary
- Fix duplicate homepage `<title>` by shortening Starlight site title to `Niko Table` and using an SEO-focused home page title.
- Improve meta descriptions on home, introduction, installation, and virtualization example (shadcn / TanStack / registry keywords).
- `head.astro`: homepage `og:type=website`, single canonical link, web manifest link, JSON-LD by page type (`WebSite` / `SoftwareSourceCode` / `TechArticle` / `WebPage`).
- `robots.txt`: `Disallow: /r/` so registry JSON is not indexed as thin URLs.
- Refresh `llms.txt`, fix `site.webmanifest` branding/icons, add 301s for newer example paths.
- Internal links on home to virtualization and row context menu examples.

## Test plan
- [x] `pnpm build`
- [ ] After deploy: confirm live title `Shadcn-Compatible React Data Table | Niko Table`
- [ ] Submit/refresh sitemap in Google Search Console


Made with [Cursor](https://cursor.com)