### PR TITLE
docs: fix @niko-table registries setup consistency

### DIFF
--- a/src/content/docs/data-grid/introduction.mdx
+++ b/src/content/docs/data-grid/introduction.mdx
@@ -41,7 +41,7 @@ Turn a Niko Table into an editable spreadsheet. You get virtualization, sort, fi
 
 <Steps>
 
-1. **Add the registry** to `components.json`:
+1. **Add the registry** under `registries` in `components.json` (merge with your existing config):
 
    ```json title="components.json"
    {

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -19,11 +19,19 @@ import { GITHUB_REPO_URL } from "@/data/env"
 
 Niko Table is not an opaque npm package — you copy the source into your project and own it. Built with TanStack Table and shadcn/ui.
 
-Add the registry once in `components.json` (`"@niko-table": "https://niko-table.com/r/{name}.json"`), then:
+Add the registry once under `registries` in `components.json`, then install:
+
+```json title="components.json"
+{
+  "registries": {
+    "@niko-table": "https://niko-table.com/r/{name}.json"
+  }
+}
+```
 
 <CliCommandCode action="run" command="shadcn@latest add @niko-table/data-table" />
 
-See [Installation](/getting-started/installation/) for registry setup and every available block.
+See [Installation](/getting-started/installation/) for merging into an existing `components.json` and every available block.
 
 ## Live Demo
 

--- a/src/content/docs/niko-table/introduction.mdx
+++ b/src/content/docs/niko-table/introduction.mdx
@@ -40,7 +40,7 @@ We now have a solid foundation to build on top of. Composable. Themeable. Custom
 
 1. **Configure the `@niko-table` registry**
 
-   Add the registry to your `components.json`:
+   Add it under `registries` in `components.json` (merge with your existing config):
 
    ```json title="components.json"
    {


### PR DESCRIPTION
## Summary
- Homepage now shows the full `registries` block for `@niko-table` instead of a misleading top-level key snippet
- Data Grid / Table introduction steps note merging into existing `components.json`

## Test plan
- [ ] Homepage install blurb matches Installation page registry shape
- [ ] Data Grid Introduction step 1 still installs via `@niko-table/data-table-grid`


Made with [Cursor](https://cursor.com)