### PR TITLE
fix: hide idle column-resize grip on bordered grids

### DIFF
--- a/src/components/niko-table/CHANGELOG.md
+++ b/src/components/niko-table/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the data-table component.
 
 #### Core
 
+- **Column-resize grip idle state** — grip bar is `opacity-0` until hover/focus/drag so it doesn’t act as a faux header divider (drifted 1–2px from real body `border-r` on bordered grids).
 - **Column resize overflow** — regular + virtualized body cells use `truncate` so shrink-via-resize ellipsizes instead of spilling into neighbors; when resize is enabled, default `minSize` is 40px (aligned with the grip clamp; TanStack’s built-in floor was 20).
 - **`DataTableDndBody` — column resize** — honors `getSize()`, layout lock, and truncate so Row DnD tables can mount `<DataTableColumnResize />` (opt out on drag-handle columns with `enableResizing: false`).
 - **DnD SSR hydration** — `TableColumnDndProvider` / `TableRowDndProvider` / `TableViewDndMenu` pass `React.useId()` to `DndContext` so `aria-describedby` no longer mismatches (`DndDescribedBy-73` vs `DndDescribedBy-1`).

--- a/src/components/niko-table/lib/column-resize-handle.tsx
+++ b/src/components/niko-table/lib/column-resize-handle.tsx
@@ -148,14 +148,14 @@ export function DataTableColumnResizeHandle<TData>({
       }}
       className="group/resize absolute top-0 right-0 z-10 flex h-full w-2 cursor-col-resize touch-none justify-end outline-none select-none"
     >
-      {/* Faint grip always visible (discoverable); a full primary bar on
-          hover, keyboard focus, or active drag. */}
+      {/* Idle: invisible — an always-on grip bar reads as a header divider
+          and drifts 1–2px from real cell `border-r`. Show on hover/focus/drag. */}
       <div
         className={cn(
-          "my-1.5 w-px rounded bg-border transition-all",
-          "group-hover/resize:my-0 group-hover/resize:w-0.5 group-hover/resize:bg-primary",
-          "group-focus-visible/resize:my-0 group-focus-visible/resize:w-0.5 group-focus-visible/resize:bg-primary",
-          isResizing && "my-0 w-0.5 bg-primary",
+          "my-1.5 w-px rounded bg-border opacity-0 transition-all",
+          "group-hover/resize:my-0 group-hover/resize:w-0.5 group-hover/resize:bg-primary group-hover/resize:opacity-100",
+          "group-focus-visible/resize:my-0 group-focus-visible/resize:w-0.5 group-focus-visible/resize:bg-primary group-focus-visible/resize:opacity-100",
+          isResizing && "my-0 w-0.5 bg-primary opacity-100",
         )}
       />
     </div>

--- a/src/content/docs/changelog.mdx
+++ b/src/content/docs/changelog.mdx
@@ -35,6 +35,7 @@ description: Latest updates and release notes for Niko Table.
 
 ### Fixed
 
+- Column-resize grip is idle-invisible (shows on hover/focus/drag) so it doesn’t read as a header divider offset from body `border-r`
 - Body cells truncate on column resize (no text spill into neighbors); default `minSize` 40px when resize is enabled
 - `DataTableDndBody` supports column resize (Row DnD + `<DataTableColumnResize />`)
 - DnD contexts use `React.useId()` to avoid SSR `aria-describedby` (`DndDescribedBy-N`) hydration mismatches


### PR DESCRIPTION
## Summary
- Hide the column-resize grip when idle (show on hover/focus/drag) so it no longer reads as a header divider offset 1–2px from body `border-r`
- No new header/cell className APIs — keep it simple

## Test plan
- [ ] Open `/examples/all-features-grid/`
- [ ] Confirm vertical rules no longer stair-step vs a faint header grip line when idle
- [ ] Hover column edge: grip appears; resize still works
- [ ] Keyboard focus the grip: still usable