### PR TITLE
docs: Radix style requirement note + changelog for server-side work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Server-Side Grid example** — editable Data Grid backed by a server: rows stream in on scroll (`onNearEnd`, no pagination) and edits travel back as a `created`/`updated`/`deleted` changeset with per-row server validation and `reconcile`; unsaved edits survive chunk merges. [Server-Side Grid](/examples/server-side-grid/)
+- **Drizzle ORM guide** — implements the server-side wire contract with Drizzle + Postgres (column mapping, filter→WHERE dispatch incl. OR logic, ORDER BY, facets as grouped counts, API route), with a live mocked demo that shows the generated SQL for the current view. [Drizzle ORM](/examples/drizzle-orm/)
+- **`normalizeFiltersFromUrl` export** from `filters/table-filter-menu` — counterpart of `serializeFiltersForUrl` for restoring advanced-menu filters from a URL or controlled state without duplicating the helper.
 - **Data Grid (`data-table-grid`)** — composable spreadsheet grid on Niko Table: `useDataGrid` + `<DataGrid>` + opt-in children (clipboard, fill, move, reorder, status bar, six cell editors). Id-addressed so sort/filter keep working. [Introduction](/data-grid/introduction/) · [API](/data-grid/api/)
 - **Persistence (`data-table-grid-changes`)** — `useGridChanges` → `{ created, updated, deleted }`, dirty set, `reconcile`. [Persistence](/examples/persistence-grid/)
 - **Inline validation** — `CellState.error` tooltip on invalid cells. [Validation](/examples/validation-grid/)
@@ -28,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Server-side examples reworked around a database-agnostic wire contract** — the table talks to one function taking a serializable `{ page, pageSize, sorting, search, columnFilters }`; a fenced `MOCK SERVER` section (with operator → SQL mapping) is the stand-in for any backend. All filters run server-side out of the box (search, faceted, slider, date incl. single-date timestamps, boolean, advanced menu AND/OR), cross-filter facets included; demos are labeled mocked and ship bigger datasets. [Server-Side Table](/examples/server-side-table/) · [Server-Side Nuqs Table](/examples/server-side-nuqs-table/)
+- **Grid examples flex-fill and breathe** — every grid example mounts `<DataTableColumnResize />` so columns fill the table width, and spaces its toolbar/status/table with `space-y-2` on `<DataGrid>`.
+- **Docs** — installation guide and homepage note that Niko Table targets shadcn's `new-york` (Radix) style; the current `shadcn init` default (`base-nova`, Base UI) is not yet supported.
 - **Column resize applies on drag-end** — `columnResizeMode: "onEnd"` with a container-level preview guide line, so memoized rows don't re-render on every mousemove during a drag.
 - **Composability** — row/column DnD import from `data-table-row-dnd-structure` / `data-table-column-dnd-structure` (virtualized twins likewise); registry packages no longer cross-ship the other axis
 - **Composability** — `DEFAULT_MIN_COLUMN_SIZE` lives in `lib/constants` so `DataTableRoot` no longer imports the resize-handle module for a constant
@@ -53,6 +59,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Registry — fresh installs were broken** — `lib/row-click.ts` and `lib/create-scroll-handler.ts` were imported by the core structure files but shipped by no registry item, so every clean `shadcn add @niko-table/data-table` failed to typecheck with module-not-found errors. Both now ship with `data-table` (#154).
+- **Server-side examples** — single-date column filters (bare ms timestamp) now match rows server-side instead of falling through to a text comparison; large page sizes scroll inside `maxHeight` instead of growing the page.
 - **Core** — keyboard nudge and double-click autosize now exit auto-fit like a drag does, so the fit no longer redistributes the space a keyboard user just removed
 - **Core** — header-fit floors use the same label fallback as the rendered title (formatted column id), apply only to resizable columns (no phantom floors on utility columns), and keep Map identity when nothing changed (no extra full-table re-render after first paint)
 - **Core** — the resize handle announces the real rendered width (`aria-valuenow`) for fill/floored columns, and an in-flight fill-column drag tears down if the table unmounts (no width committed to a dead table)

--- a/src/content/docs/changelog.mdx
+++ b/src/content/docs/changelog.mdx
@@ -7,6 +7,9 @@ description: Latest updates and release notes for Niko Table.
 
 ### Added
 
+- **Server-Side Grid** — editable grid backed by a server: rows stream in on scroll (no pagination), edits save as a validated `created`/`updated`/`deleted` changeset with `reconcile`. [example](/examples/server-side-grid/)
+- **Drizzle ORM guide** — the server-side wire contract implemented with Drizzle + Postgres, with a live mocked demo that shows the generated SQL as you filter and sort. [guide](/examples/drizzle-orm/)
+- **`normalizeFiltersFromUrl`** exported from `filters/table-filter-menu` (counterpart of `serializeFiltersForUrl`) for restoring advanced-menu filters from URL or controlled state
 - **Data Grid** (`data-table-grid`) — composable, virtualized spreadsheet grid: `useDataGrid` + `<DataGrid>` + opt-in children. [Introduction](/data-grid/introduction/)
 - **Persistence** (`data-table-grid-changes`) — `useGridChanges` → create / update / delete. [Persistence](/examples/persistence-grid/)
 - **Inline validation** — `CellState.error` tooltip on the cell. [Validation](/examples/validation-grid/)
@@ -25,6 +28,9 @@ description: Latest updates and release notes for Niko Table.
 
 ### Changed
 
+- **Server-side examples reworked** around a database-agnostic wire contract — one serializable query, a fenced `MOCK SERVER` section with operator → SQL mapping, every filter working server-side out of the box, cross-filter facets, mocked demos with bigger datasets. [Server-Side Table](/examples/server-side-table/) · [Nuqs](/examples/server-side-nuqs-table/)
+- Grid examples mount `<DataTableColumnResize />` (columns flex-fill the table width) and space toolbar/table with `space-y-2`
+- [Installation](/getting-started/installation/) notes Niko Table targets shadcn's `new-york` (Radix) style — the new `shadcn init` default (`base-nova`, Base UI) is not yet supported
 - Docs Source/API links use Astro `DocsLink` (aligned outline buttons; Starlight MDX stripped React `Button asChild`)
 - Install CLI yarn tab uses `yarn dlx`; Installation page is Prerequisites → Registry → Install first
 - [Skills](/getting-started/skills/) — Data Grid coverage + Cursor / Claude Code / Windsurf / agents install paths
@@ -41,6 +47,8 @@ description: Latest updates and release notes for Niko Table.
 
 ### Fixed
 
+- **Fresh installs were broken** — `lib/row-click.ts` and `lib/create-scroll-handler.ts` were imported by core files but shipped by no registry item; both now ship with `data-table`
+- Server-side examples: single-date filters (ms timestamps) match server-side; large page sizes scroll inside a `maxHeight` container instead of growing the page
 - Keyboard nudge and double-click autosize exit auto-fit like a drag, so the fit no longer redistributes space a keyboard user just removed
 - Header-fit floors follow the rendered title's fallback (formatted column id), apply only to resizable columns, and skip identity churn when unchanged (no extra full-table re-render on load)
 - Resize handle announces the real rendered width for fill/floored columns; an interrupted fill-column drag tears down cleanly on unmount

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -12,9 +12,17 @@ import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-c
 Before installing the DataTable component, make sure you have:
 
 1. **A React project** (Next.js, Vite, etc.)
-2. **Shadcn UI** set up in your project ([Installation Guide](https://ui.shadcn.com/docs/installation))
+2. **Shadcn UI** set up with the **`new-york` style** ([Installation Guide](https://ui.shadcn.com/docs/installation)) — see the note below
 3. **TailwindCSS** configured
 4. **TypeScript** (recommended)
+
+> **⚠️ Base UI styles are not yet supported.** Recent versions of `shadcn init` default to the Base UI generation (`"style": "base-nova"` in `components.json`). Niko Table is written against the **Radix generation** — with a Base UI style, the shared primitives (tooltip, select, slider, sortable, …) install as Base UI variants and the components won't typecheck. Before adding `@niko-table` blocks, set:
+>
+> ```json title="components.json"
+> { "style": "new-york" }
+> ```
+>
+> In an app that already has Base UI `components/ui/*` files, also reinstall the shared primitives after switching the style so their Radix variants overwrite them.
 
 ## Configure the Niko Table Registry
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -31,7 +31,7 @@ Add the registry once under `registries` in `components.json`, then install:
 
 <CliCommandCode action="run" command="shadcn@latest add @niko-table/data-table" />
 
-See [Installation](/getting-started/installation/) for merging into an existing `components.json` and every available block.
+Niko Table targets shadcn's `new-york` (Radix) style — if your `components.json` says `"style": "base-nova"` (the current `shadcn init` default), set it to `"new-york"` before installing. See [Installation](/getting-started/installation/) for details, merging into an existing `components.json`, and every available block.
 
 ## Live Demo
 


### PR DESCRIPTION
## Summary

- **Installation guide**: warning that Niko Table targets shadcn's `new-york` (Radix) style — the current `shadcn init` default (`base-nova`, Base UI) leaves ~23 type errors after install (CLI's `asChild`→`render` transform doesn't cover TooltipProvider `delayDuration`, Radix Select/Slider callback signatures, or Sortable props). Includes the `components.json` fix.
- **Homepage**: one-line style pointer next to the install command.
- **CHANGELOG.md + docs changelog**: entries for the server-side examples rework (#153), Server-Side Grid example, Drizzle ORM guide, `normalizeFiltersFromUrl` export, grid flex-fill/spacing, and the missing-lib-files registry fix (#154).

Found via fresh-install smoke test: all 31 blocks into clean Next.js apps — `new-york` style: 31/31 installed, 0 type errors; `base-nova`: ~23 errors.

## Test plan
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)