### PR TITLE
docs: accuracy pass — verify every page against source, fix 40+ discrepancies

### DIFF
--- a/src/content/docs/changelog.mdx
+++ b/src/content/docs/changelog.mdx
@@ -7,7 +7,7 @@ description: Latest updates and release notes for Niko Table.
 
 ### Added
 
-- **Base UI support** — all 31 blocks install cleanly into both shadcn generations: Radix (`new-york`) and Base UI (`base-nova`, the current `shadcn init` default). Dual-generation-safe callbacks and props; verified with fresh-app installs of every block under both styles.
+- **Base UI support** — all 31 registry items install cleanly into both shadcn generations: Radix (`new-york`) and Base UI (`base-nova`, the current `shadcn init` default). Dual-generation-safe callbacks and props; verified with fresh-app installs of every block under both styles.
 - **Server-Side Grid** — editable grid backed by a server: rows stream in on scroll (no pagination), edits save as a validated `created`/`updated`/`deleted` changeset with `reconcile`. [example](/examples/server-side-grid/)
 - **Drizzle ORM guide** — the server-side wire contract implemented with Drizzle + Postgres, with a live mocked demo that shows the generated SQL as you filter and sort. [guide](/examples/drizzle-orm/)
 - **`normalizeFiltersFromUrl`** exported from `filters/table-filter-menu` (counterpart of `serializeFiltersForUrl`) for restoring advanced-menu filters from URL or controlled state

--- a/src/content/docs/contributing/contributing-code.mdx
+++ b/src/content/docs/contributing/contributing-code.mdx
@@ -31,7 +31,7 @@ This repository is structured as follows:
     - contributing/
   - registry/new-york
     - examples/
-    - items/
+  - components/niko-table/
 
 </FileTree>
 
@@ -42,7 +42,7 @@ This repository is structured as follows:
 - `src/content/docs/examples`: Runnable table and grid example pages.
 - `src/content/docs/contributing`: How to contribute (code, requests, **docs**).
 - `src/registry/new-york/examples`: Demo components mounted by `CodePreview`.
-- `src/registry/new-york/items`: Installable registry implementations.
+- `src/components/niko-table`: Installable component sources, packaged by the root `registry.json`.
 
 For docs/example page shape, see [Documentation Guidelines](/contributing/documentation-guidelines/).
 

--- a/src/content/docs/data-grid/api.mdx
+++ b/src/content/docs/data-grid/api.mdx
@@ -83,14 +83,14 @@ Display shell for every visible cell; heavy editor mounts only while editing.
 
 Children of `<DataGrid>`. Unmounted = tree-shaken.
 
-| Component                | Capability                                  |
-| ------------------------ | ------------------------------------------- |
-| `DataGridClipboard`      | Copy / cut / paste (`resolveCell` required) |
-| `DataGridFillHandle`     | Corner fill; double-click auto-fill         |
-| `DataGridMove`           | Drag block to move (Ctrl/Cmd = copy)        |
-| `DataGridRowReorder`     | Row drag: prefer without active sort        |
-| `DataGridCrossHighlight` | Selection chrome on header / gutter         |
-| `DataGridStatusBar`      | Aggregate the selection                     |
+| Component                | Capability                                                                                    |
+| ------------------------ | --------------------------------------------------------------------------------------------- |
+| `DataGridClipboard`      | Copy / cut / paste (`resolveCell` optional — needed only for paste; copy/cut work without it) |
+| `DataGridFillHandle`     | Corner fill; double-click auto-fill                                                           |
+| `DataGridMove`           | Drag block to move (Ctrl/Cmd = copy)                                                          |
+| `DataGridRowReorder`     | Row drag: prefer without active sort                                                          |
+| `DataGridCrossHighlight` | Selection chrome on header / gutter                                                           |
+| `DataGridStatusBar`      | Aggregate the selection                                                                       |
 
 ## Dynamic columns
 

--- a/src/content/docs/data-grid/introduction.mdx
+++ b/src/content/docs/data-grid/introduction.mdx
@@ -152,7 +152,7 @@ The smallest useful grid: text cells + clipboard + fill.
        <DataGridFillHandle />
        <DataTable maxHeight={360}>
          <DataTableVirtualizedHeader />
-         <DataTableVirtualizedBody estimateSize={36}>
+         <DataTableVirtualizedBody estimateSize={37}>
            <DataTableRowContextMenuSlot>
              <GridRowMenu />
            </DataTableRowContextMenuSlot>
@@ -168,16 +168,16 @@ The smallest useful grid: text cells + clipboard + fill.
 
 Drop any of these inside `<DataGrid>`. Unmounted = zero cost.
 
-| Component                       | Capability                                         |
-| ------------------------------- | -------------------------------------------------- |
-| `DataGridClipboard`             | Copy / cut / paste (quote-aware TSV)               |
-| `DataGridFillHandle`            | Corner-drag fill; `Ctrl/Cmd+Enter` fills selection |
-| `DataGridMove`                  | Drag selection border to move (Ctrl/Cmd to copy)   |
-| `DataGridRowReorder`            | Drag rows by grip (avoid combining with sort)      |
-| `DataGridCrossHighlight`        | Row / column chrome for the selection              |
-| `DataGridStatusBar`             | Count / Sum / Avg / Min / Max                      |
-| `DataTableColumnResize`         | Drag resize; double-click to autosize              |
-| `DataGridUndo` / `DataGridRedo` | History                                            |
+| Component                       | Capability                                                                           |
+| ------------------------------- | ------------------------------------------------------------------------------------ |
+| `DataGridClipboard`             | Copy / cut / paste (quote-aware TSV)                                                 |
+| `DataGridFillHandle`            | Corner-drag fill (`Ctrl/Cmd+Enter` fill-selection works grid-wide, no handle needed) |
+| `DataGridMove`                  | Drag selection border to move (Ctrl/Cmd to copy)                                     |
+| `DataGridRowReorder`            | Drag rows by grip (avoid combining with sort)                                        |
+| `DataGridCrossHighlight`        | Row / column chrome for the selection                                                |
+| `DataGridStatusBar`             | Count / Sum / Avg / Min / Max                                                        |
+| `DataTableColumnResize`         | Drag resize; double-click to autosize                                                |
+| `DataGridUndo` / `DataGridRedo` | History                                                                              |
 
 Filters, sort, pin, and the view menu are regular Niko Table components. Nest them under `DataTableRoot` (beside or inside `<DataGrid>`). Do **not** put `DataGridUndo` / `DataGridAddRows` / clipboard outside `<DataGrid>`.
 

--- a/src/content/docs/data-grid/overview/components.mdx
+++ b/src/content/docs/data-grid/overview/components.mdx
@@ -26,14 +26,14 @@ Context-aware pieces under `grid/components/` and typed editors under `grid/cell
 
 Children of `<DataGrid>`. Unmounted = tree-shaken.
 
-| Component                | Capability                                  |
-| ------------------------ | ------------------------------------------- |
-| `DataGridClipboard`      | Copy / cut / paste (`resolveCell` required) |
-| `DataGridFillHandle`     | Corner fill; double-click auto-fill         |
-| `DataGridMove`           | Drag block to move (Ctrl/Cmd = copy)        |
-| `DataGridRowReorder`     | Row drag: prefer without active sort        |
-| `DataGridCrossHighlight` | Selection chrome on header / gutter         |
-| `DataGridStatusBar`      | Aggregate the selection                     |
+| Component                | Capability                                                                                    |
+| ------------------------ | --------------------------------------------------------------------------------------------- |
+| `DataGridClipboard`      | Copy / cut / paste (`resolveCell` optional — needed only for paste; copy/cut work without it) |
+| `DataGridFillHandle`     | Corner fill; double-click auto-fill                                                           |
+| `DataGridMove`           | Drag block to move (Ctrl/Cmd = copy)                                                          |
+| `DataGridRowReorder`     | Row drag: prefer without active sort                                                          |
+| `DataGridCrossHighlight` | Selection chrome on header / gutter                                                           |
+| `DataGridStatusBar`      | Aggregate the selection                                                                       |
 
 ### DataGridClipboard
 
@@ -48,9 +48,9 @@ Children of `<DataGrid>`. Unmounted = tree-shaken.
 </DataGrid>
 ```
 
-| Prop          | Type                                                   | Description                           |
-| ------------- | ------------------------------------------------------ | ------------------------------------- |
-| `resolveCell` | `(columnId: string, raw: string) => CellState<string>` | Map pasted / cut text into cell state |
+| Prop           | Type                                                   | Description                                                                    |
+| -------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| `resolveCell?` | `(columnId: string, raw: string) => CellState<string>` | Map pasted text into cell state (required for paste; copy/cut work without it) |
 
 ### DataGridFillHandle / DataGridMove / DataGridRowReorder
 

--- a/src/content/docs/data-grid/overview/hooks.mdx
+++ b/src/content/docs/data-grid/overview/hooks.mdx
@@ -97,9 +97,9 @@ changes.reconcile({ succeededIds, failedIds })
 
 Used by core / feature components: rarely imported from app code.
 
-| Hook                 | Role                                             |
-| -------------------- | ------------------------------------------------ |
-| `useGridKeyboard`    | Scoped keydown state machine                     |
-| `useGridNavigation`  | Arrow / Tab / Home / End movement                |
-| `useGridClipboard`   | TSV serialize / parse helpers                    |
-| `useDataGridContext` | Context (lives in core): throws outside provider |
+| Hook                              | Role                                                                     |
+| --------------------------------- | ------------------------------------------------------------------------ |
+| `useGridKeyboard`                 | Scoped keydown state machine                                             |
+| `useGridNavigation`               | Arrow / Tab / Home / End movement                                        |
+| `parseTsv` / `serializeSelection` | TSV parse / serialize helpers (plain functions, `use-grid-clipboard.ts`) |
+| `useDataGridContext`              | Context (lives in core): throws outside provider                         |

--- a/src/content/docs/examples/advanced-inline-table.mdx
+++ b/src/content/docs/examples/advanced-inline-table.mdx
@@ -68,10 +68,8 @@ First, we'll define our columns with filter metadata.
 ```tsx showLineNumbers title="columns.tsx"
 "use client"
 
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import type { DataTableColumnDef } from "@/components/niko-table/types"
 
@@ -157,10 +155,8 @@ import { DataTablePagination } from "@/components/niko-table/components/data-tab
 import { DataTableSearchFilter } from "@/components/niko-table/components/data-table-search-filter"
 import { DataTableViewMenu } from "@/components/niko-table/components/data-table-view-menu"
 import { DataTableInlineFilter } from "@/components/niko-table/components/data-table-inline-filter"
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import type { DataTableColumnDef } from "@/components/niko-table/types"
 

--- a/src/content/docs/examples/advanced-nuqs-table.mdx
+++ b/src/content/docs/examples/advanced-nuqs-table.mdx
@@ -77,10 +77,8 @@ First, we'll define our columns with filter metadata.
 ```tsx showLineNumbers title="columns.tsx"
 "use client"
 
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import type { DataTableColumnDef } from "@/components/niko-table/types"
 
@@ -200,16 +198,13 @@ import { DataTableSearchFilter } from "@/components/niko-table/components/data-t
 import { DataTableViewMenu } from "@/components/niko-table/components/data-table-view-menu"
 import { DataTableSortMenu } from "@/components/niko-table/components/data-table-sort-menu"
 import { DataTableFilterMenu } from "@/components/niko-table/components/data-table-filter-menu"
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import type {
   DataTableColumnDef,
   ExtendedColumnFilter,
 } from "@/components/niko-table/types"
-import type { SortingState } from "@tanstack/react-table"
 
 type Product = {
   id: string

--- a/src/content/docs/examples/advanced-table.mdx
+++ b/src/content/docs/examples/advanced-table.mdx
@@ -70,10 +70,8 @@ First, we'll define our columns with filter metadata.
 ```tsx showLineNumbers title="columns.tsx"
 "use client"
 
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import type { DataTableColumnDef } from "@/components/niko-table/types"
 
@@ -189,10 +187,8 @@ import { DataTableSearchFilter } from "@/components/niko-table/components/data-t
 import { DataTableViewMenu } from "@/components/niko-table/components/data-table-view-menu"
 import { DataTableSortMenu } from "@/components/niko-table/components/data-table-sort-menu"
 import { DataTableFilterMenu } from "@/components/niko-table/components/data-table-filter-menu"
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import type { DataTableColumnDef } from "@/components/niko-table/types"
 
@@ -307,19 +303,19 @@ The filter menu component allows users to create rule-based filters with multipl
 
 **Props:**
 
-| Name                  | Type                                                | Default      | Description                                            |
-| --------------------- | --------------------------------------------------- | ------------ | ------------------------------------------------------ |
-| `autoOptions`         | `boolean`                                           | `true`       | Auto-generate options for select/multiSelect columns   |
-| `showCounts`          | `boolean`                                           | `true`       | Show counts beside each option                         |
-| `dynamicCounts`       | `boolean`                                           | `true`       | Recompute counts based on currently filtered rows      |
-| `limitToFilteredRows` | `boolean`                                           | `true`       | Generate options from filtered rows only (vs all rows) |
-| `includeColumns`      | `string[]`                                          | -            | Only generate options for these column ids             |
-| `excludeColumns`      | `string[]`                                          | -            | Exclude these column ids from generation               |
-| `limitPerColumn`      | `number`                                            | -            | Limit number of generated options per column           |
-| `mergeStrategy`       | `"preserve" \| "augment" \| "replace"`              | `"preserve"` | How to handle existing static options                  |
-| `filters?`            | `ExtendedColumnFilter[]`                            | -            | Array of filters (for controlled mode)                 |
-| `onFiltersChange?`    | `(filters: ExtendedColumnFilter[] \| null) => void` | -            | Callback when filters change                           |
-| `className`           | `string`                                            | -            | Additional CSS classes                                 |
+| Name                  | Type                                                | Default      | Description                                                                    |
+| --------------------- | --------------------------------------------------- | ------------ | ------------------------------------------------------------------------------ |
+| `autoOptions`         | `boolean`                                           | `true`       | Auto-generate options for select/multiSelect columns                           |
+| `showCounts`          | `boolean`                                           | `true`       | Show counts beside each option                                                 |
+| `dynamicCounts`       | `boolean`                                           | `true`       | Counts recompute at the provider level automatically; prop kept for API parity |
+| `limitToFilteredRows` | `boolean`                                           | `true`       | Generate options from filtered rows only (vs all rows)                         |
+| `includeColumns`      | `string[]`                                          | -            | Only generate options for these column ids                                     |
+| `excludeColumns`      | `string[]`                                          | -            | Exclude these column ids from generation                                       |
+| `limitPerColumn`      | `number`                                            | -            | Limit number of generated options per column                                   |
+| `mergeStrategy`       | `"preserve" \| "augment" \| "replace"`              | `"preserve"` | How to handle existing static options                                          |
+| `filters?`            | `ExtendedColumnFilter[]`                            | -            | Array of filters (for controlled mode)                                         |
+| `onFiltersChange?`    | `(filters: ExtendedColumnFilter[] \| null) => void` | -            | Callback when filters change                                                   |
+| `className`           | `string`                                            | -            | Additional CSS classes                                                         |
 
 **Merge Strategy:**
 

--- a/src/content/docs/examples/aside-table.mdx
+++ b/src/content/docs/examples/aside-table.mdx
@@ -69,10 +69,8 @@ First, we'll define our columns.
 ```tsx showLineNumbers title="columns.tsx"
 "use client"
 
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import type { DataTableColumnDef } from "@/components/niko-table/types"
 
@@ -147,10 +145,8 @@ import { DataTableToolbarSection } from "@/components/niko-table/components/data
 import { DataTablePagination } from "@/components/niko-table/components/data-table-pagination"
 import { DataTableSearchFilter } from "@/components/niko-table/components/data-table-search-filter"
 import { DataTableViewMenu } from "@/components/niko-table/components/data-table-view-menu"
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import {
   DataTableAside,

--- a/src/content/docs/examples/basic-grid.mdx
+++ b/src/content/docs/examples/basic-grid.mdx
@@ -8,7 +8,7 @@ import CollapsiblePreview from "@/components/markdown/collapsible-preview.astro"
 import CliCommandCode from "@/components/markdown/cli-command-code/cli-command-code.astro"
 import { Aside } from "@astrojs/starlight/components"
 
-The smallest useful Data Grid: `useDataGrid` + `<DataGrid>` + `GridTextCell`. You get keyboard navigation, undo/redo, and a virtualized body. Clipboard, fill, and other features stay opt-in children you add later.
+The smallest useful Data Grid: `useDataGrid` + `<DataGrid>` + `GridTextCell`. You get keyboard navigation, undo/redo, and a virtualized body. Clipboard, fill, toolbar, and the row menu are opt-in children — the demo below mounts the common ones; leave out what you don't need.
 
 This page is the reference shape for new grid examples: see [Documentation Guidelines](/contributing/documentation-guidelines/).
 
@@ -26,13 +26,14 @@ This page is the reference shape for new grid examples: see [Documentation Guide
 
 ## What’s included
 
-| Piece            | Role                                                 |
-| ---------------- | ---------------------------------------------------- |
-| `useDataGrid`    | Headless rows, focus, edit lifecycle, undo/redo      |
-| `<DataGrid>`     | Keyboard nav + selection around `DataTable`          |
-| `<DataGridCell>` | Id-addressed cell wrapper (not TanStack `row.index`) |
-| `GridTextCell`   | Text editor (display shell; editor mounts on edit)   |
-| Virtualized body | Fixed-height scroll container required               |
+| Piece            | Role                                                  |
+| ---------------- | ----------------------------------------------------- |
+| `useDataGrid`    | Headless rows, focus, edit lifecycle, undo/redo       |
+| `<DataGrid>`     | Keyboard nav + selection around `DataTable`           |
+| `<DataGridCell>` | Id-addressed cell wrapper (not TanStack `row.index`)  |
+| `GridTextCell`   | Text editor (display shell; editor mounts on edit)    |
+| Virtualized body | Fixed-height scroll container required                |
+| Opt-in children  | Demo mounts clipboard, fill handle, toolbar, row menu |
 
 ## Composition
 
@@ -45,9 +46,9 @@ const grid = useDataGrid({
 
 <DataTableRoot data={grid.rows} columns={columns} getRowId={(r) => r.id}>
   <DataGrid grid={grid}>
-    <DataTable>
+    <DataTable maxHeight={360}>
       <DataTableVirtualizedHeader />
-      <DataTableVirtualizedBody height={360} />
+      <DataTableVirtualizedBody estimateSize={37} />
     </DataTable>
   </DataGrid>
 </DataTableRoot>

--- a/src/content/docs/examples/basic-table.mdx
+++ b/src/content/docs/examples/basic-table.mdx
@@ -60,10 +60,8 @@ First, we'll define our columns with sortable headers.
 ```tsx showLineNumbers title="columns.tsx"
 "use client"
 
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import type { DataTableColumnDef } from "@/components/niko-table/types"
 
@@ -139,10 +137,8 @@ import {
 import { DataTableToolbarSection } from "@/components/niko-table/components/data-table-toolbar-section"
 import { DataTablePagination } from "@/components/niko-table/components/data-table-pagination"
 import { DataTableViewMenu } from "@/components/niko-table/components/data-table-view-menu"
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import type { DataTableColumnDef } from "@/components/niko-table/types"
 

--- a/src/content/docs/examples/column-resize-table.mdx
+++ b/src/content/docs/examples/column-resize-table.mdx
@@ -244,11 +244,11 @@ export function OrdersTable({ rows, orgId }) {
       state={{ columnSizing }}
       onColumnSizingChange={onColumnSizingChange}
     >
+      <DataTableColumnResize />
       <DataTable>
         <DataTableHeader />
         <DataTableBody />
       </DataTable>
-      <DataTableColumnResize />
     </DataTableRoot>
   )
 }

--- a/src/content/docs/examples/drizzle-orm.mdx
+++ b/src/content/docs/examples/drizzle-orm.mdx
@@ -177,7 +177,8 @@ function columnFilterToSql(id: string, value: unknown): SQL | undefined {
   // single date filter: bare ms timestamp → match the calendar day
   if (typeof value === "number" && id === "releaseDate") {
     const day = new Date(value)
-    const next = new Date(value + 24 * 60 * 60 * 1000)
+    day.setHours(0, 0, 0, 0)
+    const next = new Date(day.getTime() + 24 * 60 * 60 * 1000)
     return and(gte(column, day), lt(column, next))
   }
 

--- a/src/content/docs/examples/faceted-filter-table.mdx
+++ b/src/content/docs/examples/faceted-filter-table.mdx
@@ -64,10 +64,8 @@ First, we'll define our columns with filter functions.
 ```tsx showLineNumbers title="columns.tsx"
 "use client"
 
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import { DataTableColumnFacetedFilterMenu } from "@/components/niko-table/components/data-table-column-faceted-filter"
 import { DataTableColumnSliderFilterMenu } from "@/components/niko-table/components/data-table-column-slider-filter-options"
@@ -192,10 +190,8 @@ import { DataTableFacetedFilter } from "@/components/niko-table/components/data-
 import { DataTableSliderFilter } from "@/components/niko-table/components/data-table-slider-filter"
 import { DataTableDateFilter } from "@/components/niko-table/components/data-table-date-filter"
 import { DataTableClearFilter } from "@/components/niko-table/components/data-table-clear-filter"
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import { DataTableColumnFacetedFilterMenu } from "@/components/niko-table/components/data-table-column-faceted-filter"
 import { DataTableColumnSliderFilterMenu } from "@/components/niko-table/components/data-table-column-slider-filter-options"
@@ -347,21 +343,21 @@ The faceted filter component shows available options with counts.
 
 **Props:**
 
-| Name                  | Type                   | Default | Description                                                                   |
-| --------------------- | ---------------------- | ------- | ----------------------------------------------------------------------------- |
-| `accessorKey`         | `keyof TData & string` | -       | The column key to filter (required)                                           |
-| `title`               | `string`               | -       | Optional override (defaults to column meta.label or accessor name)            |
-| `options`             | `Option[]`             | -       | Static options; if omitted and column meta allows, options are auto-generated |
-| `multiple`            | `boolean`              | -       | Allow multiple selections (defaults based on column variant)                  |
-| `showCounts`          | `boolean`              | `true`  | Show counts next to options                                                   |
-| `dynamicCounts`       | `boolean`              | `true`  | Counts reflect filtered rows                                                  |
-| `limitToFilteredRows` | `boolean`              | `true`  | Show only options from filtered rows (vs all rows)                            |
+| Name                  | Type                   | Default     | Description                                                                                              |
+| --------------------- | ---------------------- | ----------- | -------------------------------------------------------------------------------------------------------- |
+| `accessorKey`         | `keyof TData & string` | -           | The column key to filter (required)                                                                      |
+| `title`               | `string`               | -           | Optional override (defaults to column meta.label or accessor name)                                       |
+| `options`             | `Option[]`             | -           | Static options; if omitted and column meta allows, options are auto-generated                            |
+| `multiple`            | `boolean`              | -           | Allow multiple selections (defaults based on column variant)                                             |
+| `showCounts`          | `boolean`              | `true`      | Show counts next to options                                                                              |
+| `dynamicCounts`       | `boolean`              | `true`      | Counts reflect filtered rows                                                                             |
+| `limitToFilteredRows` | `boolean`              | `!multiple` | Show only options from filtered rows (vs all rows) — defaults on for single-select, off for multi-select |
 
 ### limitToFilteredRows
 
 The `limitToFilteredRows` prop controls whether the filter shows options from all data or only from the currently filtered rows.
 
-**When `limitToFilteredRows={true}` (default):**
+**When `limitToFilteredRows={true}` (the default for single-select):**
 
 - Options are generated from rows that match other active filters
 - Useful for filters like "Brand" or "Rating" where you want to see only relevant options

--- a/src/content/docs/examples/inline-edit-table.mdx
+++ b/src/content/docs/examples/inline-edit-table.mdx
@@ -145,8 +145,8 @@ const columns = useMemo<DataTableColumnDef<Product>[]>(
     {
       id: "name",
       accessorKey: "name",
-      header: ({ column }) => (
-        <DataTableColumnHeader column={column}>
+      header: () => (
+        <DataTableColumnHeader>
           <DataTableColumnTitle>Name</DataTableColumnTitle>
           <DataTableColumnSortMenu />
         </DataTableColumnHeader>
@@ -216,15 +216,16 @@ export function ProductsTable() {
 
   return (
     <DataTableRoot data={data} columns={columns}>
+      <DataTableToolbarSection>
+        <DataTableSearchFilter placeholder="Search products…" />
+      </DataTableToolbarSection>
       <DataTable>
-        <DataTableToolbarSection>
-          <DataTableSearchFilter placeholder="Search products…" />
-        </DataTableToolbarSection>
         <DataTableHeader />
-        <DataTableBody getRowMemoKey={inlineEdit.getRowMemoKey} />
-        <DataTableEmptyBody>...</DataTableEmptyBody>
-        <DataTablePagination />
+        <DataTableBody getRowMemoKey={inlineEdit.getRowMemoKey}>
+          <DataTableEmptyBody>...</DataTableEmptyBody>
+        </DataTableBody>
       </DataTable>
+      <DataTablePagination />
     </DataTableRoot>
   )
 }

--- a/src/content/docs/examples/row-expansion-table.mdx
+++ b/src/content/docs/examples/row-expansion-table.mdx
@@ -434,8 +434,9 @@ export function RowExpansionTableWithExport({ data }: { data: Order[] }) {
 
       <DataTable>
         <DataTableHeader />
-        <DataTableBody />
-        <DataTableEmptyBody />
+        <DataTableBody>
+          <DataTableEmptyBody />
+        </DataTableBody>
       </DataTable>
 
       <DataTablePagination />
@@ -490,8 +491,9 @@ export function RowExpansionTableWithCustomExport({ data }: { data: Order[] }) {
 
       <DataTable>
         <DataTableHeader />
-        <DataTableBody />
-        <DataTableEmptyBody />
+        <DataTableBody>
+          <DataTableEmptyBody />
+        </DataTableBody>
       </DataTable>
 
       <DataTablePagination />

--- a/src/content/docs/examples/server-side-nuqs-table.mdx
+++ b/src/content/docs/examples/server-side-nuqs-table.mdx
@@ -147,7 +147,7 @@ Because the request shape is already serialized in the URL, a server-rendered pa
 
 - Everything from the Server-Side Table applies, and
 - Table views must be shareable, bookmarkable, or survive refreshes
-- You want browser back/forward to step through filter states
+- You want back/forward to step through filter states — switch the snippet to `history: "push"` for that
 
 **❌ Consider other options when:**
 

--- a/src/content/docs/examples/tree-table.mdx
+++ b/src/content/docs/examples/tree-table.mdx
@@ -478,7 +478,7 @@ export function ControlledTreeTable({ data }: { data: Project[] }) {
 
 ## Tree Selection
 
-For hierarchical selection (selecting a parent selects all children), you'll need custom selection logic. See the [Tree Table example](/examples/tree-table/) for a complete implementation.
+For hierarchical selection (selecting a parent selects all children), you'll need custom selection logic — the live demo at the top of this page implements it; open its **Code** tab for the cascading-selection column.
 
 ## When to Use
 

--- a/src/content/docs/getting-started/components.mdx
+++ b/src/content/docs/getting-started/components.mdx
@@ -23,7 +23,7 @@ The foundation. Every other component depends on it.
 
 ## Virtualization
 
-For large datasets (1k+ rows).
+For large datasets (10k+ rows).
 
 | Name                     | What it does                                                                           |
 | ------------------------ | -------------------------------------------------------------------------------------- |

--- a/src/content/docs/getting-started/installation.mdx
+++ b/src/content/docs/getting-started/installation.mdx
@@ -238,7 +238,7 @@ The DataTable registry automatically installs a custom `components/ui/table.tsx`
 
 ### Monorepo / Non-Standard Layouts
 
-If your project uses a non-standard UI component path (e.g., `packages/ui/src/components/` instead of `src/components/ui/`), the shadcn CLI may place `table.tsx` in the wrong location. This is a [known upstream issue](https://github.com/shadcn-ui/ui/issues) with `registry:ui` path resolution.
+If your project uses a non-standard UI component path (e.g., `packages/ui/src/components/` instead of `src/components/ui/`), the shadcn CLI may place `table.tsx` in the wrong location. This is a known upstream shadcn CLI quirk with `registry:ui` path resolution.
 
 **Workaround:** After installing, check that `table.tsx` landed in the correct directory. If it was placed in a nested `ui/` folder, move it to your actual UI components path and ensure it exports `TableComponent`:
 
@@ -317,8 +317,8 @@ Let's build your first table. We'll start with a simple table and progressively 
          <span
            className={
              row.original.status === "active"
-               ? "text-green-600"
-               : "text-gray-400"
+               ? "text-success"
+               : "text-muted-foreground"
            }
          >
            {row.original.status}
@@ -404,7 +404,7 @@ Different examples require different dependencies. Here's what you need for each
 - `@tanstack/react-table`
 - Shadcn: `table`, `button`, `input`, `dropdown-menu`, `popover`, `command`, `checkbox`, `select`, `scroll-area`, `separator`, `skeleton`, `tooltip`
 - **Inline Filters**: Included in DataTable components (no additional dependencies)
-- **Sortable Rows** (optional): [DiceUI Sortable](https://www.diceui.com/docs/components/sortable) - `@dnd-kit/core`, `@dnd-kit/modifiers`, `@dnd-kit/sortable`, `@dnd-kit/utilities`, `@radix-ui/react-slot`
+- **Sortable Rows** (optional): `@niko-table/data-table-row-dnd` — installs its `@dnd-kit` dependencies automatically (built on [DiceUI Sortable](https://www.diceui.com/docs/components/sortable) patterns)
 
 ### Advanced Table with URL State (nuqs)
 
@@ -412,7 +412,7 @@ Different examples require different dependencies. Here's what you need for each
 - `nuqs` ([nuqs.dev](https://nuqs.dev/)) - Type-safe search params state manager for URL state management
 - Shadcn: All components from Advanced Table
 - **Inline Filters**: Included in DataTable components (no additional dependencies)
-- **Sortable Rows** (optional): [DiceUI Sortable](https://www.diceui.com/docs/components/sortable) - `@dnd-kit/core`, `@dnd-kit/modifiers`, `@dnd-kit/sortable`, `@dnd-kit/utilities`, `@radix-ui/react-slot`
+- **Sortable Rows** (optional): `@niko-table/data-table-row-dnd` — installs its `@dnd-kit` dependencies automatically (built on [DiceUI Sortable](https://www.diceui.com/docs/components/sortable) patterns)
 
 ## Optional Dependencies
 
@@ -430,7 +430,11 @@ nuqs provides type-safe search params state management, perfect for syncing tabl
 
 ### Sortable/Draggable Rows
 
-For drag-and-drop row reordering, follow the [DiceUI Sortable installation guide](https://www.diceui.com/docs/components/sortable).
+For drag-and-drop row reordering, install the registry block — it brings its `@dnd-kit` dependencies with it:
+
+<CliCommandCode action="run" command="shadcn@latest add @niko-table/data-table-row-dnd" />
+
+See the [Row DnD Table example](/examples/row-dnd-table/) for usage. (The sortable primitives follow [DiceUI Sortable](https://www.diceui.com/docs/components/sortable) patterns.)
 
 ## Project Structure
 

--- a/src/content/docs/getting-started/introduction.mdx
+++ b/src/content/docs/getting-started/introduction.mdx
@@ -23,7 +23,7 @@ Built for real-world applications with features like:
 - Row selection and bulk actions
 - Column visibility and reordering
 - Virtual scrolling for large datasets
-- Export to CSV/Excel
+- Export to CSV
 
 ### 🎯 Progressive Complexity
 
@@ -47,11 +47,11 @@ Since you own the code, you can:
 
 ### ♿ Accessible by Default
 
-Built on **Radix UI** primitives with semantic table markup where possible:
+Built on your shadcn generation's primitives (**Radix UI** or **Base UI**) with semantic table markup where possible:
 
 - Keyboard support in sort/filter menus and toolbar controls
 - ARIA labels on filter triggers, sliders, and clear actions
-- Screen-reader-friendly patterns via Shadcn/Radix components
+- Screen-reader-friendly patterns via shadcn/ui components
 - **jsx-a11y** lint rules on docs and source
 
 We do not claim third-party WCAG certification; treat complex tables (virtualization, DnD, pinning) like any custom UI and verify with your own accessibility checklist.
@@ -143,7 +143,7 @@ This DataTable provides you with:
 - **Composable components** - Build complex UIs from simple, reusable pieces
 - **State management** - Context-based state sharing with hook-based flexibility
 - **Performance optimization** - Virtual scrolling, memoization, and efficient rendering
-- **Accessibility** - Radix primitives, keyboard-friendly filters/menus, jsx-a11y linting (verify end-to-end in your app)
+- **Accessibility** - shadcn/ui primitives (Radix or Base UI), keyboard-friendly filters/menus, jsx-a11y linting (verify end-to-end in your app)
 - **TypeScript** - Fully typed with comprehensive type definitions
 
 ## Philosophy
@@ -267,13 +267,13 @@ const columns: DataTableColumnDef<User>[] = [
 
 ### vs Building from Scratch
 
-| Feature           | This DataTable | From Scratch        |
-| ----------------- | -------------- | ------------------- |
-| Time to implement | ✅ Minutes     | ❌ Days/weeks       |
-| Accessibility     | ✅ Built-in    | ❌ Must implement   |
-| Mobile support    | ✅ Ready       | ❌ Must build       |
-| Advanced features | ✅ Available   | ❌ Complex to build |
-| Best practices    | ✅ Included    | ❌ Must learn       |
+| Feature           | This DataTable       | From Scratch        |
+| ----------------- | -------------------- | ------------------- |
+| Time to implement | ✅ Minutes           | ❌ Days/weeks       |
+| Accessibility     | ✅ Baseline included | ❌ Must implement   |
+| Mobile support    | ✅ Ready             | ❌ Must build       |
+| Advanced features | ✅ Available         | ❌ Complex to build |
+| Best practices    | ✅ Included          | ❌ Must learn       |
 
 ## Next Steps
 

--- a/src/content/docs/getting-started/manual-installation.mdx
+++ b/src/content/docs/getting-started/manual-installation.mdx
@@ -16,6 +16,8 @@ Before copying the components, make sure you have:
 3. **TailwindCSS** configured
 4. **TypeScript** (recommended)
 
+> **Using the Base UI generation (`"style": "base-nova"`)?** Prefer the [CLI install](/getting-started/installation/) — the shadcn CLI adapts the source to Base UI idioms (`asChild` → `render`) at install time. The raw files copied on this page target the Radix (`new-york`) generation.
+
 ## Architecture Note
 
 The DataTable components use a two-layer architecture for maximum flexibility:

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -70,8 +70,8 @@ Selection, expansion, filters, sort, pagination, column visibility, export, and 
 ## Key Features
 
 - **Type-safe** - Full TypeScript support
-- **Accessible** - Radix UI primitives, ARIA labels in filters/menus, keyboard shortcuts; linted with jsx-a11y
-- **Responsive** - Full-width scroll container (`overflow-auto`); touch-friendly Radix controls; stack toolbars as needed on small screens
+- **Accessible** - shadcn/ui primitives (Radix or Base UI), ARIA labels in filters/menus, keyboard shortcuts; linted with jsx-a11y
+- **Responsive** - Full-width scroll container (`overflow-auto`); touch-friendly controls; stack toolbars as needed on small screens
 - **Customizable** - Full source code access
 - **Composable** - Mix and match components (install only the registry pieces you need)
 - **Performance** - Virtual scrolling for 10,000+ client-side rows (fixed-height scroll container)
@@ -82,7 +82,7 @@ Selection, expansion, filters, sort, pagination, column visibility, export, and 
 - [TanStack Table](https://tanstack.com/table/latest) - Headless table utilities
 - [Shadcn UI](https://ui.shadcn.com) - Beautiful UI components
 - [Tailwind CSS](https://tailwindcss.com) - Utility-first CSS
-- [Radix UI](https://www.radix-ui.com) - Accessible primitives
+- [Radix UI](https://www.radix-ui.com) / [Base UI](https://base-ui.com) - Accessible primitives (per your shadcn generation)
 - [DiceUI Sortable](https://www.diceui.com/docs/components/sortable) - Drag and drop sortable
 
 ## Community

--- a/src/content/docs/niko-table/introduction.mdx
+++ b/src/content/docs/niko-table/introduction.mdx
@@ -324,9 +324,9 @@ The `config` prop accepts a `DataTableConfig` object:
 
 | Name                 | Type      | Default | Description                                                                        |
 | -------------------- | --------- | ------- | ---------------------------------------------------------------------------------- |
-| `enablePagination`   | `boolean` | `true`  | Enable pagination.                                                                 |
-| `enableFilters`      | `boolean` | `true`  | Enable filtering.                                                                  |
-| `enableSorting`      | `boolean` | `true`  | Enable sorting.                                                                    |
+| `enablePagination`   | `boolean` | `false` | Enable pagination (auto-enabled when `DataTablePagination` is rendered).           |
+| `enableFilters`      | `boolean` | `false` | Enable filtering (auto-enabled when filter components are rendered).               |
+| `enableSorting`      | `boolean` | `false` | Enable sorting (auto-enabled when sort components are rendered).                   |
 | `enableRowSelection` | `boolean` | `false` | Enable row selection.                                                              |
 | `enableMultiSort`    | `boolean` | `true`  | Enable multi-column sorting.                                                       |
 | `enableGrouping`     | `boolean` | `false` | Enable column grouping.                                                            |

--- a/src/content/docs/niko-table/overview/components.mdx
+++ b/src/content/docs/niko-table/overview/components.mdx
@@ -361,15 +361,15 @@ import { DataTableSliderFilter } from "@/components/niko-table/components/data-t
 
 #### Props
 
-| Name          | Type                   | Default | Description                                              |
-| ------------- | ---------------------- | ------- | -------------------------------------------------------- |
-| `accessorKey` | `keyof TData & string` | -       | Column accessor key (required).                          |
-| `title`       | `string`               | -       | Custom title.                                            |
-| `min`         | `number`               | -       | Minimum value (auto-detected from data if not provided). |
-| `max`         | `number`               | -       | Maximum value (auto-detected from data if not provided). |
-| `step`        | `number`               | `1`     | Step increment.                                          |
-| `range`       | `[number, number]`     | -       | Range array `[min, max]` (overrides min/max).            |
-| `unit`        | `string`               | -       | Unit label (e.g., "$", "kg").                            |
+| Name          | Type                   | Default | Description                                                                     |
+| ------------- | ---------------------- | ------- | ------------------------------------------------------------------------------- |
+| `accessorKey` | `keyof TData & string` | -       | Column accessor key (required).                                                 |
+| `title`       | `string`               | -       | Custom title.                                                                   |
+| `min`         | `number`               | -       | Minimum value (auto-detected from data if not provided).                        |
+| `max`         | `number`               | -       | Maximum value (auto-detected from data if not provided).                        |
+| `step`        | `number`               | auto    | Step increment; auto-calculated from the range size (`1` only for ranges ≤ 20). |
+| `range`       | `[number, number]`     | -       | Range array `[min, max]` (overrides min/max).                                   |
+| `unit`        | `string`               | -       | Unit label (e.g., "$", "kg").                                                   |
 
 ### DataTableDateFilter
 
@@ -477,10 +477,8 @@ Composable column header container. Provides layout for title, actions, and filt
 </div>
 
 ```tsx showLineNumbers
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 
 const columns: DataTableColumnDef<User>[] = [
@@ -509,15 +507,11 @@ const columns: DataTableColumnDef<User>[] = [
 The `DataTableColumnHeader` is composable. You can break it down into parts to customize the layout or add custom filters.
 
 ```tsx showLineNumbers
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnActions } from "@/components/niko-table/components/data-table-column-actions"
-import {
-  DataTableColumnFilter,
-  DataTableColumnFilterTrigger,
-} from "@/components/niko-table/components/data-table-column-filter"
+import { DataTableColumnFilter } from "@/components/niko-table/components/data-table-column-filter"
+import { DataTableColumnFilterTrigger } from "@/components/niko-table/components/data-table-column-filter-trigger"
 import { DataTableColumnSortOptions } from "@/components/niko-table/components/data-table-column-sort"
 import { DataTableColumnHideOptions } from "@/components/niko-table/components/data-table-column-hide"
 import { DataTableColumnPinOptions } from "@/components/niko-table/components/data-table-column-pin"
@@ -550,10 +544,8 @@ const columns: DataTableColumnDef<User>[] = [
 **Standalone filter menus** can also be placed directly inside `DataTableColumnHeader` without needing `DataTableColumnActions`:
 
 ```tsx showLineNumbers
-import {
-  DataTableColumnHeader,
-  DataTableColumnTitle,
-} from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
+import { DataTableColumnTitle } from "@/components/niko-table/components/data-table-column-title"
 import { DataTableColumnSortMenu } from "@/components/niko-table/components/data-table-column-sort"
 import { DataTableColumnFacetedFilterMenu } from "@/components/niko-table/components/data-table-column-faceted-filter"
 import { DataTableColumnSliderFilterMenu } from "@/components/niko-table/components/data-table-column-slider-filter-options"
@@ -754,13 +746,13 @@ Faceted filter options to compose inside `DataTableColumnActions`. Shows a multi
 
 Standalone faceted filter popover for column header. Renders as a clickable button with filter icon. Auto-generates options from row data when no explicit options are provided.
 
-| Name                  | Type            | Default | Description                                                |
-| --------------------- | --------------- | ------- | ---------------------------------------------------------- |
-| `column`              | `Column<TData>` | -       | Optional override (auto-detected from context).            |
-| `options`             | `Option[]`      | -       | Static options array (auto-generated if omitted).          |
-| `multiple`            | `boolean`       | -       | Allow multiple selection.                                  |
-| `limitToFilteredRows` | `boolean`       | `true`  | Show only options from filtered rows (`false` = all rows). |
-| `className`           | `string`        | -       | Additional CSS classes.                                    |
+| Name                  | Type            | Default     | Description                                                                                              |
+| --------------------- | --------------- | ----------- | -------------------------------------------------------------------------------------------------------- |
+| `column`              | `Column<TData>` | -           | Optional override (auto-detected from context).                                                          |
+| `options`             | `Option[]`      | -           | Static options array (auto-generated if omitted).                                                        |
+| `multiple`            | `boolean`       | -           | Allow multiple selection.                                                                                |
+| `limitToFilteredRows` | `boolean`       | `!multiple` | Show only options from filtered rows (`false` = all rows); defaults on for single-select, off for multi. |
+| `className`           | `string`        | -           | Additional CSS classes.                                                                                  |
 
 ##### DataTableColumnSliderFilterOptions
 
@@ -911,6 +903,7 @@ import {
   DataTableEmptyFilteredMessage,
   DataTableEmptyActions,
 } from "@/components/niko-table/components/data-table-empty-state"
+import { DataTableEmptyBody } from "@/components/niko-table/core/data-table-structure"
 import { PackageOpen } from "lucide-react"
 
 // Complete empty state composition

--- a/src/content/docs/niko-table/overview/config.mdx
+++ b/src/content/docs/niko-table/overview/config.mdx
@@ -22,9 +22,9 @@ The configuration defines which operators are available for each filter variant:
 
 - **Text Operators**: `ilike`, `not.ilike`, `eq`, `neq`, `empty`, `not.empty`
 - **Numeric Operators**: `eq`, `neq`, `lt`, `lte`, `gt`, `gte`, `between`, `empty`, `not.empty`
-- **Date Operators**: `eq`, `neq`, `lt`, `lte`, `gt`, `gte`, `between`, `relative`
+- **Date Operators**: `eq`, `neq`, `lt`, `lte`, `gt`, `gte`, `between`, `empty`, `not.empty` (`relative` is defined in the enum but not yet wired into the menus)
 - **Boolean Operators**: `eq`, `neq`
-- **Select Operators**: `eq`, `neq`, `in`, `not.in`, `empty`, `not.empty`
+- **Select Operators**: `eq`, `neq`, `empty`, `not.empty`
 - **Multi-Select Operators**: `in`, `not.in`, `empty`, `not.empty`
 
 ### Sort Icons Configuration
@@ -33,15 +33,15 @@ Sort icons are configured per data type variant:
 
 - **Text**: `ArrowDownAZ` (asc), `ArrowDownZA` (desc), `ArrowUpDown` (unsorted)
 - **Number**: `ArrowDown01` (asc), `ArrowDown10` (desc), `ArrowUpDown` (unsorted)
-- **Date**: `Calendar` (asc), `Calendar` (desc), `ArrowUpDown` (unsorted)
-- **Boolean**: `Check` (asc), `XIcon` (desc), `ArrowUpDown` (unsorted)
+- **Date**: `ArrowUpDown` (asc), `ArrowUpDown` (desc), `Calendar` (unsorted)
+- **Boolean**: `XIcon` (asc — false first), `Check` (desc — true first), `ArrowUpDown` (unsorted)
 
 ### Sort Labels
 
 Human-readable labels for sort directions:
 
-- **Ascending**: "A-Z" (text), "0-9" (number), "Old-New" (date), "False-True" (boolean)
-- **Descending**: "Z-A" (text), "9-0" (number), "New-Old" (date), "True-False" (boolean)
+- **Ascending**: "Asc" (text), "Low to High" (number), "Oldest First" (date), "False First" (boolean)
+- **Descending**: "Desc" (text), "High to Low" (number), "Newest First" (date), "True First" (boolean)
 
 ## Feature Detection
 

--- a/src/content/docs/niko-table/overview/core.mdx
+++ b/src/content/docs/niko-table/overview/core.mdx
@@ -62,23 +62,24 @@ export function MyTable({ data }: { data: User[] }) {
 
 The `config` prop accepts a `DataTableConfig` object with the following properties:
 
-| Name                 | Type      | Default | Description                                                                                                 |
-| -------------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------- |
-| `enablePagination`   | `boolean` | `true`  | Enable pagination.                                                                                          |
-| `enableFilters`      | `boolean` | `true`  | Enable filtering.                                                                                           |
-| `enableSorting`      | `boolean` | `true`  | Enable sorting.                                                                                             |
-| `enableRowSelection` | `boolean` | `false` | Enable row selection.                                                                                       |
-| `enableMultiSort`    | `boolean` | `true`  | Enable multi-column sorting.                                                                                |
-| `enableGrouping`     | `boolean` | `false` | Enable column grouping.                                                                                     |
-| `enableExpanding`    | `boolean` | `false` | Enable row expansion.                                                                                       |
-| `manualSorting`      | `boolean` | `false` | Enable server-side sorting.                                                                                 |
-| `manualPagination`   | `boolean` | `false` | Enable server-side pagination.                                                                              |
-| `manualFiltering`    | `boolean` | `false` | Enable server-side filtering.                                                                               |
-| `pageCount`          | `number`  | -       | Total pages (required for server-side pagination).                                                          |
-| `initialPageSize`    | `number`  | `10`    | Initial page size.                                                                                          |
-| `initialPageIndex`   | `number`  | `0`     | Initial page index.                                                                                         |
-| `autoResetPageIndex` | `boolean` | -       | Auto-reset page on filter/sort change. Defaults to `false` when `manualPagination: true`, otherwise `true`. |
-| `autoResetExpanded`  | `boolean` | `true`  | Auto-reset expanded rows on filter/sort change.                                                             |
+| Name                   | Type      | Default | Description                                                                                             |
+| ---------------------- | --------- | ------- | ------------------------------------------------------------------------------------------------------- |
+| `enablePagination`     | `boolean` | `false` | Enable pagination. Auto-enabled when `DataTablePagination` is detected.                                 |
+| `enableFilters`        | `boolean` | `false` | Enable filtering. Auto-enabled when filter components are detected.                                     |
+| `enableSorting`        | `boolean` | `false` | Enable sorting. Auto-enabled when sort components are detected.                                         |
+| `enableRowSelection`   | `boolean` | `false` | Enable row selection.                                                                                   |
+| `enableMultiSort`      | `boolean` | `true`  | Enable multi-column sorting.                                                                            |
+| `enableGrouping`       | `boolean` | `true`  | Enable column grouping.                                                                                 |
+| `enableExpanding`      | `boolean` | `false` | Enable row expansion.                                                                                   |
+| `manualSorting`        | `boolean` | `false` | Enable server-side sorting.                                                                             |
+| `manualPagination`     | `boolean` | `false` | Enable server-side pagination.                                                                          |
+| `manualFiltering`      | `boolean` | `false` | Enable server-side filtering.                                                                           |
+| `pageCount`            | `number`  | -       | Total pages (required for server-side pagination).                                                      |
+| `initialPageSize`      | `number`  | `10`    | Initial page size.                                                                                      |
+| `initialPageIndex`     | `number`  | `0`     | Initial page index.                                                                                     |
+| `autoResetPageIndex`   | `boolean` | `false` | Auto-reset page on filter/sort change. Off by default (prevents flushSync warnings); opt in explicitly. |
+| `autoResetExpanded`    | `boolean` | `false` | Auto-reset expanded rows on filter/sort change.                                                         |
+| `enableColumnResizing` | `boolean` | `false` | Enable column resizing. Auto-enabled when `DataTableColumnResize` is detected.                          |
 
 ### DataTableProvider
 
@@ -188,16 +189,16 @@ import {
 
 #### Props
 
-| Name               | Type                           | Default | Description                                                                                                                                                                              |
-| ------------------ | ------------------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `className`        | `string`                       | -       | Additional CSS classes.                                                                                                                                                                  |
-| `children`         | `React.ReactNode`              | -       | Child components (Skeleton, EmptyBody).                                                                                                                                                  |
-| `onScroll`         | `(event: ScrollEvent) => void` | -       | Scroll event handler.                                                                                                                                                                    |
-| `onScrolledTop`    | `() => void`                   | -       | Called when scrolled to top.                                                                                                                                                             |
-| `onScrolledBottom` | `() => void`                   | -       | Called when scrolled to bottom.                                                                                                                                                          |
-| `scrollThreshold`  | `number`                       | `50`    | Threshold for scroll events.                                                                                                                                                             |
-| `onRowClick`       | `(row: TData) => void`         | -       | Called when a row is clicked.                                                                                                                                                            |
-| `getRowMemoKey`    | `(row: TData) => string`       | -       | Per-row key encoding external row state (inline edits, optimistic overlays). When it changes for a row, only that row re-renders. See [Inline Edit Table](/examples/inline-edit-table/). |
+| Name               | Type                                                         | Default | Description                                                                                                                                                                              |
+| ------------------ | ------------------------------------------------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `className`        | `string`                                                     | -       | Additional CSS classes.                                                                                                                                                                  |
+| `children`         | `React.ReactNode`                                            | -       | Child components (Skeleton, EmptyBody).                                                                                                                                                  |
+| `onScroll`         | `(event: ScrollEvent) => void`                               | -       | Scroll event handler.                                                                                                                                                                    |
+| `onScrolledTop`    | `() => void`                                                 | -       | Called when scrolled to top.                                                                                                                                                             |
+| `onScrolledBottom` | `() => void`                                                 | -       | Called when scrolled to bottom.                                                                                                                                                          |
+| `scrollThreshold`  | `number`                                                     | `50`    | Threshold for scroll events.                                                                                                                                                             |
+| `onRowClick`       | `(row: TData, event: React.MouseEvent<HTMLElement>) => void` | -       | Called when a row is clicked.                                                                                                                                                            |
+| `getRowMemoKey`    | `(row: TData) => string`                                     | -       | Per-row key encoding external row state (inline edits, optimistic overlays). When it changes for a row, only that row re-renders. See [Inline Edit Table](/examples/inline-edit-table/). |
 
 > **Row memo invalidation:** all six body components are wrapped in `React.memo` for performance. Column toggle / reorder / pin already invalidate rows (the `columnLayoutSignature` prop encodes them). If your column `cell` functions read **external state** (inline edit drafts, optimistic overlays) wire `getRowMemoKey` so that state change forces only the affected row to re-render.
 
@@ -588,12 +589,12 @@ import { DataTableRowDndProvider } from "@/components/niko-table/components/data
 
 #### Props
 
-| Name            | Type                     | Default | Description                                                                                   |
-| --------------- | ------------------------ | ------- | --------------------------------------------------------------------------------------------- |
-| `children`      | `React.ReactNode`        | -       | Child components.                                                                             |
-| `className`     | `string`                 | -       | Additional CSS classes.                                                                       |
-| `onRowClick`    | `(row: TData) => void`   | -       | Called when a row is clicked.                                                                 |
-| `getRowMemoKey` | `(row: TData) => string` | -       | Per-row key encoding external row state. When it changes for a row, only that row re-renders. |
+| Name            | Type                                                         | Default | Description                                                                                   |
+| --------------- | ------------------------------------------------------------ | ------- | --------------------------------------------------------------------------------------------- |
+| `children`      | `React.ReactNode`                                            | -       | Child components.                                                                             |
+| `className`     | `string`                                                     | -       | Additional CSS classes.                                                                       |
+| `onRowClick`    | `(row: TData, event: React.MouseEvent<HTMLElement>) => void` | -       | Called when a row is clicked.                                                                 |
+| `getRowMemoKey` | `(row: TData) => string`                                     | -       | Per-row key encoding external row state. When it changes for a row, only that row re-renders. |
 
 #### DataTableDndHeader
 
@@ -628,12 +629,12 @@ DnD-aware table body for column drag-and-drop. Each cell follows its column's dr
 
 #### Props
 
-| Name            | Type                     | Default | Description                                                                                   |
-| --------------- | ------------------------ | ------- | --------------------------------------------------------------------------------------------- |
-| `children`      | `React.ReactNode`        | -       | Child components.                                                                             |
-| `className`     | `string`                 | -       | Additional CSS classes.                                                                       |
-| `onRowClick`    | `(row: TData) => void`   | -       | Called when a row is clicked.                                                                 |
-| `getRowMemoKey` | `(row: TData) => string` | -       | Per-row key encoding external row state. When it changes for a row, only that row re-renders. |
+| Name            | Type                                                         | Default | Description                                                                                   |
+| --------------- | ------------------------------------------------------------ | ------- | --------------------------------------------------------------------------------------------- |
+| `children`      | `React.ReactNode`                                            | -       | Child components.                                                                             |
+| `className`     | `string`                                                     | -       | Additional CSS classes.                                                                       |
+| `onRowClick`    | `(row: TData, event: React.MouseEvent<HTMLElement>) => void` | -       | Called when a row is clicked.                                                                 |
+| `getRowMemoKey` | `(row: TData) => string`                                     | -       | Per-row key encoding external row state. When it changes for a row, only that row re-renders. |
 
 ### Virtualized DnD Components
 

--- a/src/content/docs/niko-table/overview/filters.mdx
+++ b/src/content/docs/niko-table/overview/filters.mdx
@@ -97,6 +97,25 @@ const [filters, setFilters] = useState<ExtendedColumnFilter<Product>[]>([])
 | `onFiltersChange` | `(filters: ExtendedColumnFilter<TData>[] \| null) => void` | Callback when filters change.       |
 | `className`       | `string`                                                   | Additional CSS classes.             |
 
+#### URL serialization helpers
+
+The module also exports two helpers for persisting menu filters (URL params, controlled state):
+
+```tsx showLineNumbers
+import {
+  normalizeFiltersFromUrl,
+  serializeFiltersForUrl,
+} from "@/components/niko-table/filters/table-filter-menu"
+
+// Writing: strip filterId to keep URLs short
+const urlFilters = serializeFiltersForUrl(filters)
+
+// Reading: regenerate missing filterIds deterministically
+const restored = normalizeFiltersFromUrl(urlFilters)
+```
+
+`filterId` is internal to the menu UI — deterministic regeneration keeps input focus stable across re-renders. See the [Server-Side Nuqs Table](/examples/server-side-nuqs-table/) example for full wiring.
+
 ### TableFacetedFilter
 
 Core faceted filter implementation.
@@ -523,9 +542,10 @@ import type { ExtendedColumnFilter } from "@/components/niko-table/types"
 // Basic usage with filter configuration
 const filter: ExtendedColumnFilter<Product> = {
   filterId: "price-range",
-  columnId: "price",
+  id: "price",
+  variant: "range",
   operator: "between",
-  value: [0, 100],
+  value: ["0", "100"],
 }
 
 <TableRangeFilter

--- a/src/content/docs/niko-table/overview/hooks.mdx
+++ b/src/content/docs/niko-table/overview/hooks.mdx
@@ -100,10 +100,10 @@ import { useDerivedColumnTitle } from "@/components/niko-table/hooks/use-derived
 function ColumnHeader({ column }: { column: Column<Product> }) {
   // Priority: title prop → column.meta.label → formatted accessorKey
   const title = useDerivedColumnTitle(column, "first_name")
-  // Returns "First Name" (formatted from accessorKey)
+  // Returns "FirstName" (formatLabel capitalizes; dashes/underscores become spaces, camelCase does not)
 
   const titleWithMeta = useDerivedColumnTitle(column, "firstName")
-  // Returns column.columnDef.meta.label if set, otherwise "First Name"
+  // Returns column.columnDef.meta.label if set, otherwise "FirstName"
 
   const titleWithOverride = useDerivedColumnTitle(column, "firstName", "Custom Title")
   // Returns "Custom Title" (explicit title always wins)

--- a/src/content/docs/niko-table/overview/lib.mdx
+++ b/src/content/docs/niko-table/overview/lib.mdx
@@ -365,12 +365,18 @@ const filterValue = createFilterValue(filter)
 
 ### processFiltersForLogic
 
-Processes an array of `ExtendedColumnFilter` objects and groups them by join operator (AND/OR) for TanStack Table's column filter state. Returns processed filters and the join operator map.
+Processes an array of `ExtendedColumnFilter` objects and decides how they should be routed: pure-AND rule sets go to TanStack's `columnFilters`; anything with OR (or mixed) join logic must ride in `globalFilter` instead, since TanStack combines column filters with AND only.
 
 ```tsx showLineNumbers
 import { processFiltersForLogic } from "@/components/niko-table/lib/data-table"
 
-const { processedFilters, joinOperators } = processFiltersForLogic(filters)
+const {
+  processedFilters, // filters with normalized joinOperator values
+  hasOrFilters, // any rule joined with OR
+  hasSameColumnFilters, // multiple rules target one column
+  shouldUseGlobalFilter, // true → route via globalFilter, not columnFilters
+  joinOperator, // "and" | "mixed"
+} = processFiltersForLogic(filters)
 ```
 
 ## Style Utilities
@@ -528,6 +534,7 @@ import { SYSTEM_COLUMN_IDS } from "@/components/niko-table/lib/constants"
 // Available IDs:
 SYSTEM_COLUMN_IDS.SELECT // "select" - Row selection checkbox column
 SYSTEM_COLUMN_IDS.EXPAND // "expand" - Row expansion toggle column
+SYSTEM_COLUMN_IDS.ACTIONS // "actions" - Row actions (kebab menu) column
 ```
 
 ### SYSTEM_COLUMN_ID_LIST
@@ -567,11 +574,19 @@ Walks a TanStack Table column / row set and produces deduplicated `{ label, valu
 ```tsx showLineNumbers
 import { buildFacetedOptions } from "@/components/niko-table/lib/build-faceted-options"
 
-const options = buildFacetedOptions({
-  rows: table.getCoreRowModel().rows,
-  columnId: "category",
-  dynamicCounts: true,
-})
+const options = buildFacetedOptions(
+  table,
+  table.getCoreRowModel().rows,
+  "category", // accessorKey
+  table.getState().columnFilters,
+  table.getState().globalFilter,
+  {
+    limitToFilteredRows: true,
+    dynamicCounts: true,
+    showCounts: true,
+    autoOptionsFormat: "capitalize",
+  },
+)
 // → [{ label: "Electronics", value: "electronics", count: 12 }, ...]
 ```
 


### PR DESCRIPTION
## Summary

Four parallel reviews verified every docs page (getting-started, table examples, grid docs, API overviews, changelog, contributing) against the actual source, registry.json, and example implementations. This PR fixes everything found: ~15 copy-paste-broken snippets (wrong import paths, fabricated signatures, invalid DOM nesting), ~12 wrong defaults/values (config table defaults, operator lists, sort icons/labels), and ~15 stale or misleading passages (Radix-only claims post-Base-UI, CSV/Excel, DiceUI install path, self-referencing links).

Full breakdown in the commit message.

## Test plan
- [x] Every fix re-verified against the cited source file before editing
- [x] `npm run build` (astro check + registry + astro build) passes, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)