### PR TITLE
docs: align README with current Niko Table docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,50 +2,62 @@
 
 **Nobody's table, everyone's solution.**
 
-A comprehensive, production-ready DataTable component built with [TanStack Table](https://tanstack.com/table/latest) and [Shadcn UI](https://ui.shadcn.com). Copy the code into your project, customize it to your needs, and ship with confidence.
+A shadcn-compatible React data table registry built on [TanStack Table](https://tanstack.com/table/latest) and [shadcn/ui](https://ui.shadcn.com). Not an opaque npm package: you copy the source into your project and own it.
 
-> This is not a component library you install. It's open code you own.
+> Open code you can read, change, and ship. Same model as shadcn/ui.
+
+**Docs:** [niko-table.com](https://niko-table.com)
+
+## What you get
+
+- **Data Table**: composable `DataTable*` pieces for sorting, filtering, pagination, selection, expansion, pinning, virtualization, export, and more
+- **Data Grid**: optional editable spreadsheet layer (`useDataGrid` + `<DataGrid>`) with clipboard, fill, undo/redo, typed editors, and persistence helpers
+- **Registry install**: add `@niko-table` once, then install only the blocks you need via the shadcn CLI
+- **Works with both shadcn generations**: classic Radix (`new-york`) and Base UI (`base-nova`)
 
 ## Principles
 
-Niko Table is built around the following principles:
+**Open Code.** The top layer of component code is yours to modify. Full TypeScript source, not a black box.
 
-**Open Code:** The top layer of your component code is open for modification. You get the full source code — not a black box. Modify any component, change any behavior, style anything your way.
+**Composition.** Build tables from small, predictable pieces. Start with `DataTableRoot`, add header/body, then mount filters, pagination, or grid features as you need them.
 
-**Composition:** Every table is built by composing small, predictable components. Start with `DataTableRoot`, add `DataTableHeader`, `DataTableBody`, filters, pagination — mix and match to build exactly what you need.
+**Distribution.** Flat registry files + the `shadcn` CLI. One `components.json` entry, then install by name.
 
-**Distribution:** A flat-file schema and the `shadcn` CLI make it easy to add components to your project. Run one command and you're ready to go.
+**Beautiful Defaults.** Sensible styles via shadcn/ui and Tailwind CSS, so defaults look good without a design pass.
 
-**Beautiful Defaults:** Carefully chosen default styles powered by Shadcn UI and Tailwind CSS, so you get great design out-of-the-box without any configuration.
-
-**AI-Ready:** Open code that LLMs can read, understand, and improve. No hidden abstractions, no private APIs — just clean, well-documented TypeScript.
+**AI-Ready.** Clean, documented TypeScript that LLMs can read and improve. No hidden abstractions or private APIs.
 
 ## Features
 
-- **Sorting** — Single and multi-column sorting with drag-and-drop reordering
-- **Filtering** — Global search, faceted filters, date filters, slider filters, inline filters with AND/OR logic
-- **Pagination** — Client-side and server-side with customizable page sizes
-- **Row Selection** — Individual and bulk selection with action bar
-- **Row Expansion** — Expandable rows with custom detail views
-- **Column Pinning** — Pin columns to left or right edges
-- **Column Visibility** — Show/hide columns dynamically
-- **Virtual Scrolling** — Handle 10,000+ rows with smooth performance
-- **Export** — Export all or selected rows to CSV
-- **URL State** — Persist table state in the URL with [nuqs](https://nuqs.dev)
-- **Server-Side** — Full support for server-side pagination, filtering, and sorting
-- **Tree Tables** — Hierarchical data with expandable parent rows
-- **Sidebar Panels** — Left and right aside panels for filters or detail views
-- **Composable Column Headers** — Build custom column headers with sort, filter, pin, and hide controls
-- **Empty States** — Composable empty state with filtered/unfiltered messaging
-- **Type-Safe** — Full TypeScript support with comprehensive type definitions
-- **Accessible** — Radix UI primitives, ARIA in filters/menus, keyboard shortcuts; jsx-a11y in this repo (verify in your app for full conformance)
-- **Responsive** — Mobile-friendly design with touch-friendly controls
+**Table**
+
+- Sorting (single / multi-column) and column menus
+- Filtering: global search, faceted, date, slider, inline, AND/OR logic
+- Pagination (client and server-side)
+- Row selection, expansion, context menus
+- Column pinning, visibility, resize, and DnD reorder
+- Virtual scrolling for large client-side datasets
+- CSV export, aside panels, tree tables
+- Optional URL state with [nuqs](https://nuqs.dev)
+
+**Data Grid**
+
+- Editable cells with typed editors (text, number, checkbox, date, select)
+- Keyboard nav, selection, clipboard, fill handle, undo/redo
+- Opt-in children only: unmounted features attach no listeners
+- Inline validation and create/update/delete change-sets
+
+**Quality**
+
+- Full TypeScript
+- Accessible patterns via shadcn primitives (Radix or Base UI), ARIA in filters/menus, keyboard shortcuts; jsx-a11y in this repo (verify complex tables in your app)
+- Responsive scroll container with touch-friendly controls
 
 ## Quick Start
 
-### Install via CLI (Recommended)
+### 1. Add the registry
 
-Add the registry to your project's `components.json`:
+Merge into your project's `components.json`:
 
 ```json
 {
@@ -55,7 +67,7 @@ Add the registry to your project's `components.json`:
 }
 ```
 
-Then install the core (or any add-on — see [Components](https://niko-table.com/getting-started/components/)):
+### 2. Install a block
 
 ```bash
 pnpm dlx shadcn@latest add @niko-table/data-table
@@ -67,42 +79,44 @@ URL fallback (no `components.json` change):
 pnpm dlx shadcn@latest add https://niko-table.com/r/data-table.json
 ```
 
-This copies the DataTable source into your project. You own the code. The CLI does not support wildcards like `@niko-table/**` — list items explicitly or use [Install Everything](https://niko-table.com/getting-started/installation/#install-everything).
+The CLI does not support wildcards like `@niko-table/**`. List items explicitly or use [Install Everything](https://niko-table.com/getting-started/installation/#install-everything).
 
-### Manual Installation
+See [Installation](https://niko-table.com/getting-started/installation/) and [Components](https://niko-table.com/getting-started/components/) for the full catalog (pagination, filters, virtualization, DnD, Data Grid, …).
 
-Copy the component files from `src/components/niko-table/` into your project. See the [Manual Installation Guide](https://niko-table.com/getting-started/manual-installation) for details.
+### Manual installation
 
-### Required Dependencies
+Copy files from `src/components/niko-table/` into your app. Guide: [Manual Installation](https://niko-table.com/getting-started/manual-installation/).
+
+### Dependencies
 
 ```bash
 npm install @tanstack/react-table
 ```
 
-Optional dependencies for advanced features:
+Optional:
 
 ```bash
 # Virtual scrolling
 npm install @tanstack/react-virtual
 
-# URL state management
+# URL state
 npm install nuqs
 
-# Drag and drop sorting
+# Row / column drag-and-drop
 npm install @dnd-kit/core @dnd-kit/sortable @dnd-kit/modifiers @dnd-kit/utilities
 ```
 
 ## Usage
 
-### Simple Table
+Import from **direct file paths** (no barrel `index` re-exports for UI components):
 
 ```tsx
+import { DataTableRoot } from "@/components/niko-table/core/data-table-root"
+import { DataTable } from "@/components/niko-table/core/data-table"
 import {
-  DataTableRoot,
-  DataTable,
   DataTableHeader,
   DataTableBody,
-} from "@/components/niko-table/core"
+} from "@/components/niko-table/core/data-table-structure"
 
 const columns = [
   { accessorKey: "name", header: "Name" },
@@ -121,23 +135,15 @@ export function SimpleTable({ data }) {
 }
 ```
 
-### Add Features Incrementally
+Add features by mounting more pieces under `DataTableRoot`:
 
 ```tsx
-import {
-  DataTableRoot,
-  DataTable,
-  DataTableHeader,
-  DataTableBody,
-} from "@/components/niko-table/core"
-import {
-  DataTableToolbarSection,
-  DataTableSearchFilter,
-  DataTableFilterMenu,
-  DataTableViewMenu,
-  DataTableSortMenu,
-  DataTablePagination,
-} from "@/components/niko-table/components"
+import { DataTableToolbarSection } from "@/components/niko-table/components/data-table-toolbar-section"
+import { DataTableSearchFilter } from "@/components/niko-table/components/data-table-search-filter"
+import { DataTableFilterMenu } from "@/components/niko-table/components/data-table-filter-menu"
+import { DataTableViewMenu } from "@/components/niko-table/components/data-table-view-menu"
+import { DataTableSortMenu } from "@/components/niko-table/components/data-table-sort-menu"
+import { DataTablePagination } from "@/components/niko-table/components/data-table-pagination"
 
 export function AdvancedTable({ data, columns }) {
   return (
@@ -171,43 +177,59 @@ export function AdvancedTable({ data, columns }) {
 }
 ```
 
+Need an editable spreadsheet? Start with the [Data Grid introduction](https://niko-table.com/data-grid/introduction/).
+
 ## Architecture
 
-Niko Table uses a **two-layer architecture** for maximum flexibility:
+Two layers (one-way dependency: shared → niko-table → registry → docs):
 
-**Components** (`/components/`) — Context-aware wrappers that use `useDataTable()` to automatically get the table instance from `DataTableRoot`. Zero prop drilling, recommended for most use cases.
+**Components** (`/components/`, `DataTable*` prefix): context-aware wrappers that call `useDataTable()`. Zero prop drilling; recommended for most apps.
 
 ```tsx
-<DataTableSearchFilter /> // Automatically connected via context
+<DataTableSearchFilter /> {/* table from DataTableRoot context */}
 ```
 
-**Filters** (`/filters/`) — Core implementations that accept a `table` prop directly. Use these when building custom components or managing the table instance yourself.
+**Filters** (`/filters/`, `Table*` prefix): accept a `table` prop. Use when you manage the TanStack instance yourself or build custom wrappers.
 
 ```tsx
-<TableSearchFilter table={table} /> // Direct table prop
+<TableSearchFilter table={table} />
 ```
 
 ```
 niko-table/
-├── core/          # DataTableRoot, context, structure
-├── components/    # Context-aware components (DataTable*, column headers, empty states)
-├── filters/       # Core filter implementations (Table*)
-├── hooks/         # Custom React hooks
-├── config/        # Feature detection and configuration
+├── core/          # DataTableRoot, DataTable, structure (incl. virtualized / DnD)
+├── components/    # Context-aware DataTable* wrappers
+├── filters/       # Direct-prop Table* primitives
+├── grid/          # Data Grid (useDataGrid, DataGrid, cells, features)
+├── hooks/         # Table and grid hooks
+├── config/        # Feature detection
 ├── lib/           # Utilities, constants, formatting
-└── types/         # TypeScript type definitions
+└── types/         # TypeScript types (may use types/index.ts)
 ```
 
 ## Documentation
 
-Full documentation with interactive examples is available at **[niko-table.com](https://niko-table.com)**.
+Interactive docs and examples: **[niko-table.com](https://niko-table.com)**
 
-- [Introduction](https://niko-table.com/getting-started/introduction) — Philosophy and architecture
-- [Installation](https://niko-table.com/getting-started/installation) — Setup your project
-- [Simple Table](https://niko-table.com/examples/simple-table/) — Your first table
-- [Basic Table](https://niko-table.com/examples/basic-table/) — Pagination and sorting
-- [Advanced Table](https://niko-table.com/examples/advanced-table/) — Full filtering
-- [Server-Side Table](https://niko-table.com/examples/server-side-table/) — Server-side data
+**Getting started**
+
+- [Introduction](https://niko-table.com/getting-started/introduction/)
+- [Installation](https://niko-table.com/getting-started/installation/)
+- [Components](https://niko-table.com/getting-started/components/)
+
+**Table examples**
+
+- [Simple Table](https://niko-table.com/examples/simple-table/)
+- [Advanced Table](https://niko-table.com/examples/advanced-table/)
+- [Virtualization](https://niko-table.com/examples/virtualization-table/)
+- [Server-Side](https://niko-table.com/examples/server-side-table/)
+
+**Data Grid**
+
+- [Introduction](https://niko-table.com/data-grid/introduction/)
+- [Composed Grid](https://niko-table.com/examples/composed-grid/)
+- [Cell Types](https://niko-table.com/examples/cell-types-grid/)
+- [Persistence](https://niko-table.com/examples/persistence-grid/)
 
 ## Development
 
@@ -226,15 +248,15 @@ cp .env.example .env
 pnpm dev
 ```
 
-The documentation site will be available at `http://localhost:4321`.
+Docs site: `http://localhost:4321`.
 
-### Build the Registry
+### Build the registry
 
 ```bash
 pnpm registry:build
 ```
 
-Test installing a component from your local registry:
+Install from a local registry:
 
 ```bash
 npx shadcn@latest add http://localhost:4321/r/data-table.json
@@ -242,24 +264,22 @@ npx shadcn@latest add http://localhost:4321/r/data-table.json
 
 ## Contributing
 
-We welcome contributions! Please read the [Contributing Guide](CONTRIBUTING.md) before submitting a pull request.
+See [CONTRIBUTING.md](CONTRIBUTING.md) and:
 
-- [Contributing Code](https://niko-table.com/contributing/contributing-code)
-- [Feature Requests](https://niko-table.com/contributing/feature-request)
-- [Component Requests](https://niko-table.com/contributing/component-request)
+- [Contributing Code](https://niko-table.com/contributing/contributing-code/)
+- [Feature Requests](https://niko-table.com/contributing/feature-request/)
+- [Component Requests](https://niko-table.com/contributing/component-request/)
 
 ## Credits
 
-Built on top of excellent open-source work:
+Built on excellent open-source work:
 
-- [TanStack Table](https://tanstack.com/table) by Tanner Linsley — The headless table library that powers everything
-- [Shadcn UI](https://ui.shadcn.com) by Shadcn — Beautiful, accessible component primitives
-- [sadmann7](https://github.com/sadmann7) — Major inspiration for filter components and table patterns:
-  - [TableCN](https://github.com/sadmann7/tablecn) — Inspired filter menu, inline filter, faceted filter, and slider filter
-  - [DiceUI Sortable](https://www.diceui.com/docs/components/sortable) — Drag and drop sortable for row reordering
-- [nuqs](https://nuqs.dev/) by François Best — Type-safe search params state manager
-- [Web Dev Simplified Registry](https://github.com/WebDevSimplified/wds-shadcn-registry) by Kyle Cook — Registry implementation pattern
+- [TanStack Table](https://tanstack.com/table) by Tanner Linsley
+- [shadcn/ui](https://ui.shadcn.com) by shadcn
+- [sadmann7](https://github.com/sadmann7): [TableCN](https://github.com/sadmann7/tablecn), [DiceUI Sortable](https://www.diceui.com/docs/components/sortable)
+- [nuqs](https://nuqs.dev/) by François Best
+- [Web Dev Simplified Registry](https://github.com/WebDevSimplified/wds-shadcn-registry) by Kyle Cook
 
 ## License
 
-Licensed under the [MIT License](LICENSE).
+[MIT](LICENSE)

--- a/src/components/niko-table/README.md
+++ b/src/components/niko-table/README.md
@@ -30,6 +30,7 @@ niko-table/
 └── types/          # TypeScript types (types/index.ts is the types module)
 ```
 
+Each of those folders has a short `README.md` with import notes and links.
 **No barrel exports** for UI modules. Import from the file path directly (tree-shaking + shadcn copy pattern). Types may use `types/index.ts`.
 
 ```tsx

--- a/src/components/niko-table/README.md
+++ b/src/components/niko-table/README.md
@@ -1,761 +1,56 @@
-# Niko Table - React Data Table Composition System
+# Niko Table
 
 **Nobody's table, everyone's solution.**
 
-Niko Table provides a modern, flexible composition-based approach to building advanced data tables with hybrid state management. All components are self-contained and designed for maximum flexibility and reusability.
+Composable, shadcn-compatible data table source you copy into your project. Built on [TanStack Table](https://tanstack.com/table/latest) and [shadcn/ui](https://ui.shadcn.com). Not an opaque npm package: you own the code.
 
-## Key Benefits
+Full docs and live examples: **[niko-table.com](https://niko-table.com)**
 
-1. **Flexibility**: Mix and match components as needed
-2. **Reusability**: Components can be used independently
-3. **Maintainability**: Smaller, focused components are easier to maintain
-4. **Customization**: Easy to create custom layouts and behaviors
-5. **Type Safety**: Full TypeScript support with proper generics
-6. **Auto-detection**: Features are automatically enabled based on included components
-7. **Advanced Features**: Virtualization, row expansion, loading states, and more
+This folder is the source that the registry ships. Prefer installing via the CLI (`@niko-table/...`) or following [Manual Installation](https://niko-table.com/getting-started/manual-installation/).
 
-## Directory Structure
+## What lives here
 
-The composition system is organized into logical directories for better maintainability:
+| Area           | Role                                                                                 |
+| -------------- | ------------------------------------------------------------------------------------ |
+| **Data Table** | `DataTableRoot` + structure + filters / menus / pagination / virtualization / DnD    |
+| **Data Grid**  | Optional editable spreadsheet layer (`useDataGrid` + `<DataGrid>` + opt-in children) |
 
-```bash
+## Directory structure
+
+```
 niko-table/
-├── core/                    # Essential table components
-│   ├── data-table-root.tsx
-│   ├── data-table-context.tsx
-│   ├── data-table.tsx
-│   ├── data-table-error-boundary.tsx
-│   ├── data-table-structure.tsx              # Header, Body, EmptyBody, Skeleton, Loading (consolidated for easy copy/paste)
-│   └── data-table-virtualized-structure.tsx  # VirtualizedHeader, VirtualizedBody, VirtualizedEmptyBody, VirtualizedSkeleton, VirtualizedLoading (consolidated)
-├── components/              # All user-facing components
-│   ├── data-table-search-filter.tsx          # Context-aware components
-│   ├── data-table-faceted-filter.tsx
-│   ├── data-table-slider-filter.tsx
-│   ├── data-table-date-filter.tsx
-│   ├── data-table-sort-menu.tsx
-│   ├── data-table-filter-menu.tsx
-│   ├── data-table-inline-filter.tsx
-│   ├── data-table-view-menu.tsx
-│   ├── data-table-clear-filter.tsx
-│   ├── data-table-pagination.tsx
-│   ├── data-table-export-button.tsx
-│   ├── table-column-header.tsx                # Reusable UI components
-│   ├── data-table-toolbar-section.tsx
-│   ├── data-table-aside.tsx
-│   ├── data-table-selection-bar.tsx
-│   └── data-table-empty-state.tsx
-├── filters/                 # Core implementation components
-│   ├── table-date-filter.tsx
-│   ├── table-faceted-filter.tsx
-│   ├── table-filter-menu.tsx
-│   ├── table-range-filter.tsx
-│   ├── table-slider-filter.tsx
-│   ├── table-sort-menu.tsx
-│   ├── table-pagination.tsx
-│   └── table-export-button.tsx
-├── config/                  # Configuration and utilities
-│   ├── data-table.ts
-│   └── feature-detection.ts
-├── types/                   # Type definitions
-├── hooks/                   # Custom hooks
-├── lib/                     # Utility functions
-└── examples/                # Working examples
+├── core/           # DataTableRoot, DataTable, context, structure
+│                   # (regular, virtualized, row/column DnD, virtualized DnD)
+├── components/     # Context-aware wrappers (DataTable* prefix, useDataTable())
+├── filters/        # Direct-prop primitives (Table* prefix, accept table)
+├── grid/           # Data Grid: core, components, cells, hooks, types, config
+├── hooks/          # Table helpers (debounce, flash, scroll, options, …)
+├── config/         # Feature detection
+├── lib/            # Utilities, constants, filter fns, resize handle, …
+└── types/          # TypeScript types (types/index.ts is the types module)
+```
+
+**No barrel exports** for UI modules. Import from the file path directly (tree-shaking + shadcn copy pattern). Types may use `types/index.ts`.
+
+```tsx
+// ✅
+import { DataTableRoot } from "@/components/niko-table/core/data-table-root"
+import { DataTablePagination } from "@/components/niko-table/components/data-table-pagination"
+
+// ❌ do not add or use index.ts re-exports for core / components / filters / …
 ```
 
 ## Architecture
 
-### Core Components
+One-way layers: shared → niko-table → registry → documentation.
 
-- **`DataTableRoot`**: The main provider component that sets up the table context and TanStack Table instance. Supports both pre-configured table instances and direct props mode.
-- **`DataTable`**: The container component that wraps the table structure
-- **`DataTableHeader`**: Renders the table header with sortable columns
-- **`DataTableBody`**: Renders the table body with rows
-- **`DataTableEmptyBody`**: Renders empty state when no data is available
-- **`DataTableSkeleton`**: Renders skeleton loading state
-- **`DataTableErrorBoundary`**: Error boundary wrapper for robust error handling
+### Two-layer table pattern
 
-### Virtualization Components
-
-For large datasets with optimal performance:
-
-- **`DataTableVirtualizedHeader`**: Virtualized table header
-- **`DataTableVirtualizedBody`**: Virtualized table body for rendering thousands of rows
-- **`DataTableVirtualizedEmptyBody`**: Empty state for virtualized tables
-
-### Action Components
-
-Comprehensive filtering and management capabilities:
-
-- **`DataTableSearchFilter`**: Global search input with debouncing
-- **`DataTableFacetedFilter`**: Multi-select filter for categorical data
-- **`DataTableSliderFilter`**: Range slider for numeric values
-- **`DataTableDateFilter`**: Date picker for date filtering
-- **`DataTableSortMenu`**: Menu for managing column sorting
-- **`DataTableFilterMenu`**: Command palette-style interface for quickly adding filters
-- **`DataTableInlineFilter`**: Inline filter editor with advanced operators
-- **`DataTableViewMenu`**: Column visibility toggle menu
-- **`DataTableClearFilter`**: Button to clear all active filters
-
-### Pagination Components
-
-- **`DataTablePagination`**: Full-featured pagination controls with page size selection (located in `actions/`)
-- **`TablePagination`**: Alternative pagination component (located in `filters/`)
-
-### Advanced Filter Wrappers
-
-Context-aware wrapper components for advanced filtering:
-
-- **`TableDateFilter`**: Date filtering with context
-- **`TableFacetedFilter`**: Faceted filtering with context
-- **`TableFilterMenu`**: Filter menu with context
-- **`TableRangeFilter`**: Range filtering for numeric/date ranges
-- **`TableSliderFilter`**: Slider filtering with context
-- **`TableSortMenu`**: Sorting menu with context
-
-### Reusable UI Components
-
-- **`TableColumnHeader`**: Sortable column header with proper styling
-- **`DataTableToolbarSection`**: Flexible toolbar container for filters, search, and actions
-- **`DataTableAside`**: Sidebar component for filters/actions
-- **`DataTableSelectionBar`**: Floating action bar for selected rows
-- **`DataTableEmpty*`**: Composition components for empty states (Icon, Message, FilteredMessage, Actions, Title, Description)
-
-### Context System
-
-The `DataTableContext` provides the TanStack Table instance to all child components, allowing them to access table state and methods without prop drilling. Use the `useDataTable()` hook to access the context.
-
-## Advanced Column Configuration
-
-The composition system supports comprehensive column configuration with meta properties for advanced filtering, sorting, and display:
-
-### Column Meta Properties
-
-```tsx
-import { TableColumnHeader } from "@/components/niko-table/components"
-import type { DataTableColumnDef } from "@/components/niko-table/types"
-
-const columns: DataTableColumnDef<Product>[] = [
-  {
-    accessorKey: "name",
-    header: ({ column }) => <TableColumnHeader column={column} />,
-    meta: {
-      label: "Product Name", // Display label for filters/sorting
-      placeholder: "Search products...", // Placeholder text for search
-      variant: "text", // Filter variant: text, number, select, etc.
-      icon: Text, // Icon component for UI
-      unit: "$", // Unit display for numeric fields
-      options: [
-        // Options for select variants
-        { label: "Active", value: "active" },
-        { label: "Inactive", value: "inactive" },
-      ],
-      range: [0, 100], // Range for numeric/date filters
-      // Dynamic options (select/multiSelect only)
-      // If options are omitted and variant is select/multiSelect, wrappers can auto-generate them
-      autoOptions: true, // per-column opt-in/out (defaults to wrapper prop)
-      showCounts: true, // show counts next to labels (can be dynamic)
-      dynamicCounts: true, // recompute counts from filtered rows
-      mergeStrategy: "augment", // preserve | augment | replace relative to static options
-    },
-    enableColumnFilter: true, // Enable filtering for this column
-    enableSorting: true, // Enable sorting for this column
-    enableHiding: true, // Allow column to be hidden
-  },
-]
-```
-
-### Supported Filter Variants
-
-- **`text`**: Text input for string filtering
-- **`number`**: Number input with optional unit display
-- **`select`**: Select dropdown for categorical data
-- **`date`**: Date picker for date filtering
-- **`boolean`**: Boolean toggle for true/false values
-
-### Column Features
-
-- **`enableColumnFilter`**: Enable/disable filtering for the column
-- **`enableSorting`**: Enable/disable sorting for the column (default: true)
-- **`enableHiding`**: Allow column to be hidden/shown in view options (default: true)
-
-### Important: Use TableColumnHeader
-
-Always use `TableColumnHeader` for proper column sorting functionality:
-
-```tsx
-// ✅ Correct - enables sorting
-header: ({ column }) => <TableColumnHeader column={column} />,
-
-// ✅ Also correct - with custom title
-header: ({ column }) => <TableColumnHeader column={column} title="Product Name" />,
-
-// ❌ Incorrect - no sorting functionality
-header: "Product Name",
-```
-
-## Auto-Detection Feature
-
-The composition pattern includes intelligent auto-detection that automatically enables features based on the components you include and column definitions:
-
-- **`<DataTablePagination />`** → Automatically enables pagination
-- **`<DataTableSearchFilter />`** → Automatically enables global filtering
-- **`<DataTableFacetedFilter />`** or other filter components → Automatically enables column filtering
-- **Row selection** → Automatically enabled if columns include a "select" column
-- **Row expansion** → Automatically enabled if columns include an "expand" column or `expandedContent` in meta
-- **Sorting** → Enabled by default for all columns (can be disabled per column with `enableSorting: false`)
-
-**Key Point**: Features are intelligently detected from your component composition and column configuration. No manual feature flags needed in most cases!
-
-## Usage Patterns
-
-### Simple Table (Minimal)
-
-```tsx
-import {
-  DataTableRoot,
-  DataTable,
-  DataTableHeader,
-  DataTableBody,
-  DataTableSkeleton,
-  DataTableEmptyBody,
-} from "@/components/niko-table/core"
-
-<DataTableRoot data={data} columns={columns}>
-  <DataTable>
-    <DataTableHeader />
-    <DataTableBody>
-      <DataTableSkeleton />
-      <DataTableEmptyBody />
-    </DataTableBody>
-  </DataTable>
-</DataTableRoot>
-```
-
-### Basic Table with Pagination
-
-```tsx
-import {
-  DataTableRoot,
-  DataTable,
-  DataTableHeader,
-  DataTableBody,
-} from "@/components/niko-table/core"
-import {
-  DataTableToolbarSection,
-  DataTablePagination,
-  DataTableViewMenu,
-} from "@/components/niko-table/components"
-
-<DataTableRoot data={data} columns={columns}>
-  <DataTableToolbarSection className="justify-between">
-    <h2 className="text-lg font-semibold">Products</h2>
-    <DataTableViewMenu />
-  </DataTableToolbarSection>
-  <DataTable>
-    <DataTableHeader />
-    <DataTableBody />
-  </DataTable>
-  <DataTablePagination pageSizeOptions={[5, 10, 20]} />
-</DataTableRoot>
-```
-
-### Advanced Table with Filtering and Sorting
-
-```tsx
-import {
-  DataTableRoot,
-  DataTable,
-  DataTableHeader,
-  DataTableBody,
-  DataTableEmptyBody,
-} from "@/components/niko-table/core"
-import {
-  DataTableToolbarSection,
-  DataTablePagination,
-  DataTableSearchFilter,
-  DataTableViewMenu,
-  DataTableClearFilter,
-  DataTableSortMenu,
-  DataTableFilterMenu,
-} from "@/components/niko-table/components"
-
-<DataTableRoot data={data} columns={columns}>
-  <DataTableToolbarSection>
-    <DataTableToolbarSection className="px-0">
-      <DataTableSearchFilter placeholder="Search..." />
-      <DataTableViewMenu />
-    </DataTableToolbarSection>
-    <DataTableToolbarSection className="px-0">
-      <DataTableSortMenu className="ml-auto" />
-      <DataTableFilterMenu />
-      <DataTableClearFilter />
-    </DataTableToolbarSection>
-  </DataTableToolbarSection>
-  <DataTable>
-    <DataTableHeader />
-    <DataTableBody>
-      <DataTableEmptyBody />
-    </DataTableBody>
-  </DataTable>
-  <DataTablePagination />
-</DataTableRoot>
-```
-
-### Virtualized Table for Large Datasets
-
-```tsx
-import {
-  DataTableRoot,
-  DataTable,
-  DataTableVirtualizedHeader,
-  DataTableVirtualizedBody,
-  DataTableVirtualizedEmptyBody,
-} from "@/components/niko-table/core"
-import {
-  DataTableToolbarSection,
-  DataTableSearchFilter,
-  DataTablePagination,
-} from "@/components/niko-table/components"
-
-<DataTableRoot data={largeData} columns={columns}>
-  <DataTableToolbarSection>
-    <DataTableSearchFilter placeholder="Search logs..." />
-  </DataTableToolbarSection>
-  <DataTable>
-    <DataTableVirtualizedHeader />
-    <DataTableVirtualizedBody height={600}>
-      <DataTableVirtualizedEmptyBody />
-    </DataTableVirtualizedBody>
-  </DataTable>
-  <DataTablePagination pageSizeOptions={[50, 100, 200, 500]} />
-</DataTableRoot>
-```
-
-**✨ Auto-detection**: Features are automatically enabled based on the components you include!
-
-## Component Props
-
-### DataTableRoot
-
-Core provider component that sets up the table context.
-
-**Option 1: Pre-configured table instance**
-
-- `table`: TanStack Table instance (created externally)
-- `columns?`: DataTableColumnDef array (optional if using pre-configured table)
-- `isLoading?`: Loading state
-- `className?`: Additional CSS classes
-
-**Option 2: Direct props mode**
-
-- `columns`: DataTableColumnDef array (required)
-- `data`: Table data (required)
-- `config?`: Configuration object for feature toggles
-- `getRowId?`: Custom row ID function
-- `isLoading?`: Loading state
-- `className?`: Additional CSS classes
-- Event handlers: `onGlobalFilterChange`, `onPaginationChange`, `onSortingChange`, etc.
-
-**Configuration Object (`config`)**
-
-- `enablePagination?`: boolean
-- `enableFilters?`: boolean
-- `enableSorting?`: boolean (default: true)
-- `enableRowSelection?`: boolean
-- `enableMultiSort?`: boolean (default: true)
-- `enableGrouping?`: boolean
-- `enableExpanding?`: boolean
-- `manualSorting?`: boolean (for server-side)
-- `manualPagination?`: boolean (for server-side)
-- `manualFiltering?`: boolean (for server-side)
-- `pageCount?`: number (for server-side pagination)
-- `initialPageSize?`: number (default: 10)
-- `initialPageIndex?`: number (default: 0)
-
-### DataTable
-
-Container component for the table structure.
-
-- `className?`: Additional CSS classes
-
-### DataTableHeader / DataTableVirtualizedHeader
-
-Renders the table header with sortable columns.
-
-- `className?`: Additional CSS classes
-
-### DataTableBody / DataTableVirtualizedBody
-
-Renders the table body with rows.
-
-**DataTableBody:**
-
-- `className?`: Additional CSS classes
-
-**DataTableVirtualizedBody:**
-
-- `height`: Fixed height for virtualization (required)
-- `className?`: Additional CSS classes
-
-### DataTableToolbarSection
-
-Flexible toolbar container for organizing filters and actions.
-
-- `className?`: Additional CSS classes
-- `children`: React.ReactNode
-
-### DataTablePagination
-
-Full-featured pagination controls.
-
-- `pageSizeOptions?`: number\[] (default: \[10, 20, 30, 40, 50\])
-- `className?`: Additional CSS classes
-
-### DataTableSearchFilter
-
-Global search input with debouncing.
-
-- `placeholder?`: string (default: "Search...")
-- `className?`: Additional CSS classes
-
-### DataTableViewMenu
-
-Column visibility toggle menu.
-
-- `className?`: Additional CSS classes
-
-### DataTableSortMenu
-
-Menu for managing column sorting.
-
-- `className?`: Additional CSS classes
-
-### DataTableFilterMenu
-
-Command palette-style interface for adding filters.
-
-- `className?`: Additional CSS classes
-- `autoOptions?`: boolean (default: true) — auto-generate options for select/multiSelect columns lacking static options
-- `showCounts?`: boolean (default: true) — show counts for options
-- `dynamicCounts?`: boolean (default: true) — counts reflect currently filtered rows
-- `includeColumns?`: string[] — restrict generation to these column ids
-- `excludeColumns?`: string[] — skip generation for these column ids
-- `limitPerColumn?`: number — cap the number of generated options per column
-- `mergeStrategy?`: "preserve" | "augment" | "replace" — how to handle existing static options
-
-### DataTableClearFilter
-
-Button to clear all active filters.
-
-- `className?`: Additional CSS classes
-
-### DataTableInlineFilter
-
-Inline filter editor with advanced operators.
-
-- `className?`: Additional CSS classes
-- `autoOptions?`: boolean (default: true)
-- `showCounts?`: boolean (default: true)
-- `dynamicCounts?`: boolean (default: true)
-- `includeColumns?`: string[]
-- `excludeColumns?`: string[]
-- `limitPerColumn?`: number
-- `mergeStrategy?`: "preserve" | "augment" | "replace"
-
-## Dynamic option generation (select/multiSelect)
-
-You can avoid manually listing options for categorical columns. If a column has `meta.variant = "select" | "multiSelect"` and no `meta.options`, `DataTableFilterMenu` and `DataTableInlineFilter` can auto-generate options from your table’s data.
-
-Rules:
-
-- If `meta.options` exist → treated as static.
-  - `mergeStrategy = "preserve"` (default): keep as-is.
-  - `mergeStrategy = "augment"`: keep your labels/values, add counts to matching values.
-  - `mergeStrategy = "replace"`: override with generated options.
-- `showCounts` controls whether counts are shown.
-- `dynamicCounts` determines whether counts come from filtered rows (true) or all rows (false).
-- Per-column `meta.showCounts` and `meta.dynamicCounts` override wrapper props.
-
-Wrapper usage:
-
-```tsx
-<DataTableFilterMenu autoOptions showCounts dynamicCounts mergeStrategy="augment" />
-<DataTableInlineFilter autoOptions includeColumns={["status", "category"]} />
-```
-
-Per-column overrides:
-
-```tsx
-const columns: DataTableColumnDef<Product>[] = [
-  {
-    accessorKey: "status",
-    header: ({ column }) => <TableColumnHeader column={column} />,
-    enableColumnFilter: true,
-    meta: {
-      label: "Status",
-      variant: "select",
-      options: [
-        { label: "Open", value: "open" },
-        { label: "Closed", value: "closed" },
-      ],
-      mergeStrategy: "augment", // add live counts to existing options
-      dynamicCounts: true,
-      showCounts: true,
-    },
-  },
-  {
-    accessorKey: "category",
-    header: ({ column }) => <TableColumnHeader column={column} />,
-    enableColumnFilter: true,
-    meta: {
-      label: "Category",
-      variant: "multiSelect",
-      autoOptions: true, // no options provided → generate from data
-      showCounts: true,
-      dynamicCounts: true,
-    },
-  },
-]
-```
-
-How counts update:
-
-- With `dynamicCounts=true`, counts are computed from `table.getFilteredRowModel()` so they react to other active filters.
-- With `dynamicCounts=false`, counts are computed from `table.getCoreRowModel()` (base data).
-
-## Advanced Features
-
-### Virtualization
-
-For large datasets (10,000+ rows), use virtualization components for optimal performance:
-
-```tsx
-import {
-  DataTableRoot,
-  DataTable,
-  DataTableVirtualizedHeader,
-  DataTableVirtualizedBody,
-  DataTableVirtualizedEmptyBody,
-} from "@/components/niko-table/core"
-
-<DataTableRoot data={largeData} columns={columns}>
-  <DataTable>
-    <DataTableVirtualizedHeader />
-    <DataTableVirtualizedBody height={600}>
-      <DataTableVirtualizedEmptyBody />
-    </DataTableVirtualizedBody>
-  </DataTable>
-</DataTableRoot>
-```
-
-### Row Expansion
-
-Add expandable content to rows using the `expandedContent` meta property:
-
-```tsx
-const columns: DataTableColumnDef<Product>[] = [
-  {
-    id: "expand",
-    header: "",
-    meta: {
-      expandedContent: row => (
-        <div className="bg-gray-50 p-4">
-          <h3>Details for {row.name}</h3>
-          <p>{row.description}</p>
-        </div>
-      ),
-    },
-  },
-  // ... other columns
-]
-```
-
-### Loading States
-
-Show skeleton loading state during data fetching:
-
-```tsx
-import { DataTableSkeleton } from "@/components/niko-table/core"
-
-const [isLoading, setIsLoading] = React.useState(false)
-
-<DataTableRoot data={data} columns={columns} isLoading={isLoading}>
-  <DataTable>
-    <DataTableHeader />
-    <DataTableBody>
-      <DataTableSkeleton rows={5} />
-      <DataTableEmptyBody />
-    </DataTableBody>
-  </DataTable>
-</DataTableRoot>
-```
-
-### Custom Toolbar Actions
-
-```tsx
-import { useDataTable } from "@/components/niko-table/core"
-
-function CustomToolbar() {
-  const { table } = useDataTable()
-
-  const handleExport = () => {
-    const selectedRows = table.getFilteredSelectedRowModel().rows
-    console.log(
-      "Exporting:",
-      selectedRows.map(row => row.original),
-    )
-  }
-
-  return (
-    <DataTableToolbarSection>
-      <DataTableSearchFilter placeholder="Search..." />
-      <Button onClick={handleExport}>Export Selected</Button>
-      <DataTableClearFilter />
-    </DataTableToolbarSection>
-  )
-}
-
-
-<DataTableRoot columns={columns} data={data}>
-  <CustomToolbar />
-  <DataTable>
-    <DataTableHeader />
-    <DataTableBody />
-  </DataTable>
-</DataTableRoot>
-```
-
-### Accessing Table Instance
-
-```tsx
-import { useDataTable } from "@/components/niko-table/core"
-
-function CustomComponent() {
-  const { table, isLoading } = useDataTable()
-
-  const selectedRows = table.getFilteredSelectedRowModel().rows
-  const filteredData = table.getFilteredRowModel().rows
-
-  return (
-    <div>
-      <p>Selected: {selectedRows.length}</p>
-      <p>Filtered: {filteredData.length}</p>
-      <p>Loading: {isLoading ? "Yes" : "No"}</p>
-    </div>
-  )
-}
-```
-
-## Migration from Monolithic Component
-
-### Before (Monolithic)
-
-```tsx
-<DataTable
-  columns={columns}
-  data={data}
-  enableRowSelection={true}
-  enablePagination={true}
-  showToolbar={true}
-  showPagination={true}
-  enableVirtualization={true}
-  customDataTableToolbar={<CustomToolbar />}
-  customDataTablePagination={<CustomPagination />}
-/>
-```
-
-### After (Composition)
-
-```tsx
-import {
-  DataTableRoot,
-  DataTable,
-  DataTableHeader,
-  DataTableVirtualizedBody,
-  DataTableVirtualizedEmptyBody,
-} from "@/components/niko-table/core"
-import { DataTablePagination } from "@/components/niko-table/components"
-
-<DataTableRoot columns={columns} data={data}>
-  <CustomToolbar />
-  <DataTable>
-    <DataTableHeader />
-    <DataTableVirtualizedBody height={600}>
-      <DataTableVirtualizedEmptyBody />
-    </DataTableVirtualizedBody>
-  </DataTable>
-  <CustomPagination />
-</DataTableRoot>
-```
-
-**Key Changes:**
-
-- Replace single `DataTable` component with composition pattern
-- Use `DataTableRoot` as the provider
-- Wrap table structure with `DataTable` container
-- Use specific header/body components instead of props
-- Features auto-detected from component usage
-- Row selection auto-enabled by "select" column in columns array
-
-## Examples
-
-See the `examples/` directory for complete working examples:
-
-### Basic Examples
-
-- `simple.tsx`: Minimal table with no toolbar or pagination
-- `basic.tsx`: Basic table with sorting, pagination, and column visibility
-- `basic-state.tsx`: Basic table with controlled state management
-- `search.tsx`: Table with global search functionality
-- `search-state.tsx`: Table with search and controlled state
-
-### Advanced Examples
-
-- `advanced.tsx`: Advanced table with filtering, sorting, and multiple filter types
-- `advanced-state.tsx`: Advanced table with controlled state management
-- `advanced-inline.tsx`: Advanced table with inline filter editing
-- `advanced-inline-state.tsx`: Advanced inline table with controlled state
-- `advanced-nuqs.tsx`: Advanced table with internal state (no URL persistence)
-- `advanced-nuqs-state.tsx`: **NEW** - Advanced table with URL state management using nuqs (state persists in URL)
-
-### Feature-Specific Examples
-
-- `faceted.tsx`: Table with faceted filters for categorical data
-- `faceted-state.tsx`: Faceted table with controlled state
-- `row-selection.tsx`: Table with row selection capabilities
-- `row-selection-state.tsx`: Row selection with controlled state
-- `row-expansion.tsx`: Table with expandable rows
-- `row-expansion-state.tsx`: Row expansion with controlled state
-- `aside.tsx`: Table with sidebar components
-- `aside-state.tsx`: Table with sidebar and controlled state
-
-### Performance Examples
-
-- `virtualization-table.tsx`: Large dataset (10,000+ rows) with virtualization
-- `virtualization-table-state.tsx`: Virtualized table with controlled state
-- `pagination-loading.tsx`: Table with pagination loading states
-
-### Advanced Data Structures
-
-- `tree-table.tsx`: Hierarchical tree-structured data
-- `tree-table-state.tsx`: Tree table with controlled state
-
-**Note**: Examples with `-state.tsx` suffix demonstrate controlled state management patterns.
-
-## State Management
-
-The composition system supports flexible state management approaches:
-
-### 1. Internal State (Default)
-
-Let `DataTableRoot` manage all state internally:
+**Components** (`/components/`, `DataTable*`): context-aware. Call `useDataTable()` from `DataTableRoot`. Recommended for apps.
 
 ```tsx
 <DataTableRoot data={data} columns={columns}>
-  <DataTableToolbarSection>
-    <DataTableSearchFilter />
-    <DataTableViewMenu />
-  </DataTableToolbarSection>
+  <DataTableSearchFilter />
   <DataTable>
     <DataTableHeader />
     <DataTableBody />
@@ -764,321 +59,121 @@ Let `DataTableRoot` manage all state internally:
 </DataTableRoot>
 ```
 
-### 2. Controlled State (Parent-Managed)
-
-Control specific state values from parent component:
+**Filters** (`/filters/`, `Table*`): accept `table` directly. Use when you own the TanStack instance or wrap custom UI.
 
 ```tsx
-const [globalFilter, setGlobalFilter] = useState("")
-const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 10 })
-
-<DataTableRoot
-  data={data}
-  columns={columns}
-  onGlobalFilterChange={setGlobalFilter}
-  onPaginationChange={setPagination}
-  initialState={{
-    globalFilter,
-    pagination,
-  }}
->
-  <DataTableToolbarSection>
-    <DataTableSearchFilter />
-  </DataTableToolbarSection>
-  <DataTable>
-    <DataTableHeader />
-    <DataTableBody />
-  </DataTable>
-  <DataTablePagination />
-</DataTableRoot>
+<TableSearchFilter table={table} />
 ```
 
-### 3. Pre-configured Table Instance
+### Feature detection
 
-Create your own table instance with full control:
+Mounting children (pagination, search, filters, resize markers, …) and column config drive which TanStack features attach. You usually do not need a full manual feature flag list.
 
-```tsx
-import { useReactTable, getCoreRowModel } from "@tanstack/react-table"
+Notes:
 
-const table = useReactTable({
-  data,
-  columns,
-  getCoreRowModel: getCoreRowModel(),
-  // ... your custom configuration
-})
+- **`enableSorting` defaults off** until config or detection enables it
+- Row selection / expansion follow system columns (`select`, `expand`) and meta
+- Column resize: mount `<DataTableColumnResize />` (and related packages as needed)
 
-<DataTableRoot table={table}>
-  <DataTableToolbarSection>
-    <DataTableSearchFilter />
-  </DataTableToolbarSection>
-  <DataTable>
-    <DataTableHeader />
-    <DataTableBody />
-  </DataTable>
-  <DataTablePagination />
-</DataTableRoot>
-```
+### DnD (three tiers)
 
-### Server-Side Data Management
+Built on `@dnd-kit`. Import axis-specific structure files (no combined DnD structure shims):
 
-For server-side pagination, sorting, and filtering:
+1. **Filters**: `TableRowDndProvider`, `TableDraggableRow`, `TableColumnDndProvider`, …
+2. **Components**: `DataTableRowDndProvider`, `DataTableColumnDndProvider`, …
+3. **Core structure**:
+   - Row: `data-table-row-dnd-structure`, `data-table-virtualized-row-dnd-structure`
+   - Column: `data-table-column-dnd-structure`, `data-table-virtualized-column-dnd-structure`
 
-```tsx
-<DataTableRoot
-  data={data}
-  columns={columns}
-  config={{
-    manualPagination: true,
-    manualSorting: true,
-    manualFiltering: true,
-    pageCount: totalPages, // from server
-  }}
-  onPaginationChange={handlePaginationChange}
-  onSortingChange={handleSortingChange}
-  onColumnFiltersChange={handleFiltersChange}
->
-  {/* ... components */}
-</DataTableRoot>
-```
+**Constraint:** row DnD should not be combined with sorting/filtering (order conflicts). Column DnD is safe with other features.
 
-### 4. URL State Management (with nuqs)
+### Data Grid
 
-Persist table state in the URL for shareable links and page refresh persistence.
+Under `grid/`:
 
-For a complete working example with all table state persisted in the URL (pagination, sorting, filters, search, column visibility, inline filters), see `examples/advanced-nuqs-state.tsx`.
+- **Core**: `useDataGrid`, `<DataGrid>`, context, feature registration
+- **Components**: clipboard, fill, move, toolbar, status bar, row reorder, …
+- **Cells**: display shell + typed editors (`GridTextCell`, …)
+- **Hooks / types / config**: persistence helpers, column APIs, shortcuts metadata
 
-**Key Benefits:**
+Mount only the children you need under `<DataGrid>`. Unmounted features attach no listeners. See [Data Grid introduction](https://niko-table.com/data-grid/introduction/).
 
-- Table state persists on page refresh
-- Share links with filters/sorting/pagination applied
-- Browser back/forward navigation works
-- Better UX for bookmarking specific views
-
-The example demonstrates using nuqs directly with TanStack Table following the official nuqs best practices.
-
-## Quick Start
+## Minimal usage
 
 ```tsx
+import { DataTableRoot } from "@/components/niko-table/core/data-table-root"
+import { DataTable } from "@/components/niko-table/core/data-table"
 import {
-  DataTableRoot,
-  DataTable,
   DataTableHeader,
   DataTableBody,
-} from "@/components/niko-table/core"
-import {
-  DataTableToolbarSection,
-  DataTableSearchFilter,
-  DataTableViewMenu,
-  DataTablePagination,
-} from "@/components/niko-table/components"
-import { TableColumnHeader } from "@/components/niko-table/filters"
-import type { DataTableColumnDef } from "@/components/niko-table/types"
+} from "@/components/niko-table/core/data-table-structure"
 
-// Define your columns with proper typing
-const columns: DataTableColumnDef<Product>[] = [
-  {
-    accessorKey: "name",
-    header: ({ column }) => <TableColumnHeader column={column} />,
-    enableColumnFilter: true,
-    meta: {
-      label: "Product Name",
-      variant: "text",
-      placeholder: "Search products...",
-    },
-  },
-  {
-    accessorKey: "price",
-    header: ({ column }) => <TableColumnHeader column={column} />,
-    enableColumnFilter: true,
-    meta: {
-      label: "Price",
-      variant: "number",
-      unit: "$",
-    },
-    cell: ({ row }) => `$${row.getValue("price")}`,
-  },
-  // ... more columns
-]
-
-export function MyDataTable() {
+export function SimpleTable({ data, columns }) {
   return (
     <DataTableRoot data={data} columns={columns}>
-      <DataTableToolbarSection>
-        <DataTableSearchFilter placeholder="Search..." />
-        <DataTableViewMenu />
-      </DataTableToolbarSection>
       <DataTable>
         <DataTableHeader />
         <DataTableBody />
       </DataTable>
-      <DataTablePagination />
     </DataTableRoot>
   )
 }
 ```
 
-### Key Benefits
+Virtualized tables need a constrained height on `DataTable` (e.g. `height={600}` or `className="max-h-[600px]"`). Prefer `onNearEnd` over `onScrolledBottom` for infinite scroll, and guard fetches with `isFetching`.
 
-1. **Flexible State Management**: Choose between internal, controlled, or pre-configured table
-2. **Composition-First**: Build exactly what you need with composable components
-3. **Auto-Detection**: Features automatically enabled based on component usage
-4. **Full Type Safety**: Complete TypeScript support with proper generics
-5. **Easy Testing**: Each component can be tested independently
-6. **Modern Architecture**: Built on TanStack Table v8 with latest React patterns
-7. **Performance Optimized**: Built-in virtualization for large datasets
-8. **Loading States**: Integrated skeleton loading and empty states
+## Column meta (filters / labels)
 
-## Loading States
-
-The DataTable composition system includes built-in loading state support for better UX during data fetching operations.
-
-### Basic Loading Usage
+Extend columns with `meta` for labels, filter variants, options, counts, etc. Types live in `types/index.ts` (TanStack module augmentation).
 
 ```tsx
-import {
-  DataTableRoot,
-  DataTable,
-  DataTableHeader,
-  DataTableBody,
-  DataTableSkeleton,
-  DataTableEmptyBody,
-} from "@/components/niko-table/core"
+import type { DataTableColumnDef } from "@/components/niko-table/types"
+import { DataTableColumnHeader } from "@/components/niko-table/components/data-table-column-header"
 
-export function MyTable() {
-  const [data, setData] = React.useState([])
-  const [isLoading, setIsLoading] = React.useState(true)
-
-  React.useEffect(() => {
-    fetchData()
-      .then(setData)
-      .finally(() => setIsLoading(false))
-  }, [])
-
-  return (
-    <DataTableRoot data={data} columns={columns} isLoading={isLoading}>
-      <DataTable>
-        <DataTableHeader />
-        <DataTableBody>
-          <DataTableSkeleton rows={5} />
-          <DataTableEmptyBody />
-        </DataTableBody>
-      </DataTable>
-    </DataTableRoot>
-  )
-}
+const columns: DataTableColumnDef<Product>[] = [
+  {
+    accessorKey: "status",
+    header: () => <DataTableColumnHeader />,
+    meta: {
+      label: "Status",
+      variant: "multiSelect",
+      options: [
+        { label: "Active", value: "active" },
+        { label: "Inactive", value: "inactive" },
+      ],
+    },
+    enableColumnFilter: true,
+  },
+]
 ```
 
-### Loading State Features
+Composable column chrome: `DataTableColumnHeader`, `DataTableColumnActions`, sort / pin / hide / filter options in `/components`.
 
-- **Automatic Skeleton Display**: Shows skeleton rows during loading
-- **Customizable Row Count**: Configure the number of skeleton rows via `rows` prop
-- **Context Integration**: `isLoading` state available throughout the table via `useDataTable()` hook
-- **Smooth Transitions**: Seamless transition between loading and loaded states
-- **Server-Side Support**: Works with server-side pagination and filtering
+## Row menus
 
-### Accessing Loading State in Custom Components
+Define row actions once as a declarative component using `useDataTableRow` + `RowMenuItem` / `RowMenuSub` from `data-table-row-menu`. Drop the same component into the kebab cell (`DataTableRowMenuScope surface="dropdown"`) and `<DataTableRowContextMenuSlot>`. It renders for the surface in context. Context-scope hooks throw outside their provider.
 
-```tsx
-import { useDataTable } from "@/components/niko-table/core"
+## Conventions
 
-function CustomComponent() {
-  const { isLoading, setIsLoading } = useDataTable()
+- Direct file imports only (except `types/index.ts`)
+- Semantic color tokens (`bg-success`, `text-destructive`), not hardcoded palette colors
+- Deterministic mock data in examples (no `Math.random()` / `Date.now()`) for SSR-safe demos
+- Prefer overview MDX + examples on the docs site over duplicating long tutorials here
 
-  const handleRefresh = async () => {
-    setIsLoading(true)
-    await fetchData()
-    setIsLoading(false)
-  }
+## Docs map
 
-  return (
-    <Button onClick={handleRefresh} disabled={isLoading}>
-      {isLoading ? "Refreshing..." : "Refresh"}
-    </Button>
-  )
-}
-```
+| Topic               | Link                                                 |
+| ------------------- | ---------------------------------------------------- |
+| Introduction        | https://niko-table.com/getting-started/introduction/ |
+| Installation        | https://niko-table.com/getting-started/installation/ |
+| Components catalog  | https://niko-table.com/getting-started/components/   |
+| Table overview      | https://niko-table.com/niko-table/overview/core/     |
+| Data Grid           | https://niko-table.com/data-grid/introduction/       |
+| Changelog (package) | [./CHANGELOG.md](./CHANGELOG.md)                     |
+| Site changelog      | https://niko-table.com/changelog/                    |
 
-### Common Use Cases
+## Related notes in this folder
 
-1. **Initial Data Loading**: Show skeleton while fetching initial data
-2. **Pagination Loading**: Display skeleton when loading new pages
-3. **Search/Filter Loading**: Show skeleton during search or filter operations
-4. **Refresh Operations**: Indicate data is being refreshed
-5. **Optimistic Updates**: Show loading state during mutations
-
-## Benefits of Composition Pattern
-
-1. **Explicit Structure**: The component tree clearly shows what features are enabled - no hidden magic
-2. **Easier Testing**: Each component can be tested independently in isolation
-3. **Better Performance**: Only render the components you need - no unused feature overhead
-4. **Flexible Layouts**: Easy to create custom layouts and arrangements with standard React patterns
-5. **Reusable Components**: All components work independently and can be used in different contexts
-6. **Full Type Safety**: Complete TypeScript support with proper generics and inference
-7. **Auto-Detection**: Smart feature detection based on column config and component usage
-8. **Extensible**: Easy to add custom components that integrate with the table context
-9. **Modern Patterns**: Built on React best practices and TanStack Table v8
-10. **Developer Experience**: Clear API, excellent IDE autocomplete, and helpful error messages
-
-## Best Practices
-
-1. **Always use `TableColumnHeader`** for sortable columns instead of plain strings
-2. **Define column meta properties** for consistent filtering and display behavior
-3. **Include `DataTableSkeleton` and `DataTableEmptyBody`** in your body for better UX
-4. **Use virtualization components** (`DataTableVirtualizedBody`) for datasets over 1,000 rows
-5. **Leverage auto-detection** instead of manually configuring feature flags
-6. **Use TypeScript** for full type safety and autocomplete support
-7. **Wrap toolbar actions** in `DataTableToolbarSection` for consistent spacing
-8. **Pass `isLoading` prop** to `DataTableRoot` for integrated loading states
-
-## Troubleshooting
-
-### Sorting not working
-
-- Make sure you're using `<TableColumnHeader column={column} />` instead of plain strings
-- Check that `enableSorting` is not set to `false` on the column
-
-### Filtering not showing
-
-- Ensure columns have `enableColumnFilter: true`
-- Add `meta.variant` and `meta.label` properties to columns
-- Include filter components like `DataTableFilterMenu` in your toolbar
-
-### Pagination not appearing
-
-- Include `<DataTablePagination />` in your component tree
-- Check that you have enough data to paginate (more rows than page size)
-
-### Empty state not showing
-
-- Make sure `<DataTableEmptyBody />` is included inside `<DataTableBody>`
-- Verify that your data array is actually empty when you expect it to be
-
-### Performance issues with large datasets
-
-- Use virtualization components (`DataTableVirtualizedBody`) for 1,000+ rows
-- Increase page size options in `DataTablePagination` for fewer re-renders
-- Consider server-side pagination for very large datasets (100,000+ rows)
-
-## API Reference
-
-For detailed API documentation, see:
-
-- **TanStack Table Documentation**: https://tanstack.com/table/latest
-- **Column Definition Types**: See `types/index.ts` for `DataTableColumnDef`
-- **Filter Variants**: See `lib/constants.ts` for available filter types
-- **Hooks**: See `hooks/` directory for custom hooks like `useDataTable`, `useURLState`, etc.
-
-## Contributing
-
-When contributing new components or features:
-
-1. Follow the composition pattern - components should work independently
-2. Add proper TypeScript types and JSDoc comments
-3. Include examples in the `examples/` directory
-4. Update this README with new features and components
-5. Test with both small and large datasets
-6. Ensure accessibility (keyboard navigation, screen readers)
-
-## License
-
-This component is part of the Niko Table project.
+- [CHANGELOG.md](./CHANGELOG.md): package-level release notes
+- [EMPTY_STATE_COMPOSITION.md](./EMPTY_STATE_COMPOSITION.md): empty-state composition details
+- [PERFORMANCE_ANALYSIS.md](./PERFORMANCE_ANALYSIS.md): historical performance notes

--- a/src/components/niko-table/components/README.md
+++ b/src/components/niko-table/components/README.md
@@ -1,0 +1,14 @@
+# components/
+
+Context-aware wrappers (`DataTable*` prefix). They call `useDataTable()` from `DataTableRoot` so you avoid prop drilling. Recommended for app composition.
+
+Examples: search, faceted / date / slider filters, sort / view / filter menus, pagination, export, selection bar, aside, column header chrome, resize / auto-fit markers, row / column DnD providers, row context menu slot.
+
+```tsx
+import { DataTableSearchFilter } from "@/components/niko-table/components/data-table-search-filter"
+import { DataTablePagination } from "@/components/niko-table/components/data-table-pagination"
+```
+
+For direct `table` prop APIs, see [`../filters/`](../filters/).
+
+Docs: [Components overview](https://niko-table.com/niko-table/overview/components/) · parent [README](../README.md)

--- a/src/components/niko-table/config/README.md
+++ b/src/components/niko-table/config/README.md
@@ -1,0 +1,12 @@
+# config/
+
+Feature detection and default table config used by `DataTableRoot`.
+
+| File                   | Role                                                                             |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| `feature-detection.ts` | Infer features from children / columns (pagination, filters, resize, sorting, …) |
+| `data-table.ts`        | Shared config helpers / defaults                                                 |
+
+Sorting stays off until config or detection enables it. Mount markers like `<DataTableColumnResize />` participate in detection.
+
+Parent [README](../README.md)

--- a/src/components/niko-table/core/README.md
+++ b/src/components/niko-table/core/README.md
@@ -1,0 +1,32 @@
+# core/
+
+Table foundation: root provider, scroll container, context, and structure (header/body) including virtualized and DnD variants.
+
+## Files
+
+| File                                              | Exports (main)                                                           |
+| ------------------------------------------------- | ------------------------------------------------------------------------ |
+| `data-table-root.tsx`                             | `DataTableRoot`                                                          |
+| `data-table.tsx`                                  | `DataTable` (scroll / height container)                                  |
+| `data-table-context.tsx`                          | `useDataTable`, active-cell helpers                                      |
+| `data-table-structure.tsx`                        | `DataTableHeader`, `DataTableBody`, empty / skeleton / loading           |
+| `data-table-virtualized-structure.tsx`            | `DataTableVirtualizedHeader`, `DataTableVirtualizedBody`, flex header, … |
+| `data-table-row-dnd-structure.tsx`                | Row-DnD body / related structure                                         |
+| `data-table-column-dnd-structure.tsx`             | Column-DnD header / body                                                 |
+| `data-table-virtualized-row-dnd-structure.tsx`    | Virtualized row DnD                                                      |
+| `data-table-virtualized-column-dnd-structure.tsx` | Virtualized column DnD                                                   |
+| `data-table-error-boundary.tsx`                   | Error boundary                                                           |
+
+Import from the file path (no barrels):
+
+```tsx
+import { DataTableRoot } from "@/components/niko-table/core/data-table-root"
+import {
+  DataTableHeader,
+  DataTableBody,
+} from "@/components/niko-table/core/data-table-structure"
+```
+
+Virtualized bodies need a fixed height on `DataTable`. Prefer axis-specific DnD structure files (no combined DnD shims).
+
+Docs: [Core overview](https://niko-table.com/niko-table/overview/core/) · parent [README](../README.md)

--- a/src/components/niko-table/filters/README.md
+++ b/src/components/niko-table/filters/README.md
@@ -1,0 +1,16 @@
+# filters/
+
+Direct-prop primitives (`Table*` prefix). Pass `table` (or related TanStack pieces) yourself. Use when building custom wrappers or managing the table instance outside `DataTableRoot` context.
+
+Includes filter UIs, pagination, export, column header pieces, and low-level DnD primitives (`TableRowDndProvider`, `TableColumnDndProvider`, …).
+
+```tsx
+import { TableSearchFilter } from "@/components/niko-table/filters/table-search-filter"
+import { TablePagination } from "@/components/niko-table/filters/table-pagination"
+
+<TableSearchFilter table={table} />
+```
+
+Context-aware counterparts live in [`../components/`](../components/).
+
+Docs: [Filters overview](https://niko-table.com/niko-table/overview/filters/) · parent [README](../README.md)

--- a/src/components/niko-table/grid/README.md
+++ b/src/components/niko-table/grid/README.md
@@ -1,0 +1,23 @@
+# grid/
+
+Optional editable spreadsheet layer on top of the data table. Same open-code / registry model.
+
+```
+grid/
+├── core/         # useDataGrid wiring via DataGrid, context, feature registration
+├── components/   # Clipboard, fill, move, toolbar, status bar, reorder, menus, …
+├── cells/        # Display shell + typed editors (text, number, checkbox, date, select, …)
+├── hooks/        # useDataGrid, navigation, clipboard, columns, changes, …
+├── types/        # Cell / row / grid types
+└── config/       # Shortcut metadata
+```
+
+**Composable:** mount only the children you need under `<DataGrid>`. Unmounted features attach no listeners.
+
+```tsx
+import { useDataGrid } from "@/components/niko-table/grid/hooks/use-data-grid"
+import { DataGrid } from "@/components/niko-table/grid/core/data-grid"
+import { DataGridClipboard } from "@/components/niko-table/grid/components/grid-clipboard"
+```
+
+Docs: [Data Grid introduction](https://niko-table.com/data-grid/introduction/) · [API](https://niko-table.com/data-grid/api/) · parent [README](../README.md)

--- a/src/components/niko-table/hooks/README.md
+++ b/src/components/niko-table/hooks/README.md
@@ -1,0 +1,18 @@
+# hooks/
+
+Table-level React hooks (not the Data Grid hooks under `grid/hooks/`).
+
+| Hook                          | Role                                |
+| ----------------------------- | ----------------------------------- |
+| `use-debounce.ts`             | Debounced values (search, …)        |
+| `use-generated-options.ts`    | Faceted option generation from rows |
+| `use-derived-column-title.ts` | Label resolution for columns        |
+| `use-data-table-flash.ts`     | Flash / highlight helpers           |
+| `use-data-table-scroll.ts`    | Scroll-into-view helpers            |
+| `use-keyboard-shortcut.ts`    | Shortcut binding helper             |
+
+```tsx
+import { useDebounce } from "@/components/niko-table/hooks/use-debounce"
+```
+
+Grid-specific hooks: [`../grid/hooks/`](../grid/). Parent [README](../README.md)

--- a/src/components/niko-table/lib/README.md
+++ b/src/components/niko-table/lib/README.md
@@ -1,0 +1,19 @@
+# lib/
+
+Shared utilities used by core, components, and filters. Import by file (no barrel).
+
+Notable modules:
+
+| File                                                          | Role                                    |
+| ------------------------------------------------------------- | --------------------------------------- |
+| `constants.ts`                                                | Shared constants (e.g. min column size) |
+| `data-table.ts`                                               | Table helpers                           |
+| `filter-functions.ts` / `filter-rows.ts`                      | Filtering                               |
+| `build-faceted-options.ts`                                    | Facet option building                   |
+| `format.ts`                                                   | Display formatting                      |
+| `styles.ts`                                                   | Pinning / shared style helpers          |
+| `column-resize-handle.tsx`                                    | Resize grip UI                          |
+| `use-column-auto-fit.ts` / `use-column-sizing-persistence.ts` | Sizing helpers                          |
+| `row-click.ts` / `create-scroll-handler.ts`                   | Interaction / scroll                    |
+
+Parent [README](../README.md)

--- a/src/components/niko-table/types/README.md
+++ b/src/components/niko-table/types/README.md
@@ -1,0 +1,13 @@
+# types/
+
+TypeScript types and TanStack Table module augmentation (`ColumnMeta`, `TableMeta`, column defs, filters, …).
+
+This is the one place that uses a module entry:
+
+```tsx
+import type { DataTableColumnDef } from "@/components/niko-table/types"
+```
+
+(`types/index.ts` is stripped at build time for types; do not add UI barrel files elsewhere.)
+
+Parent [README](../README.md) · docs [Types](https://niko-table.com/niko-table/overview/types/)


### PR DESCRIPTION
## Summary
- Rewrite README to match docs: open-code registry (not opaque npm), Data Table + Data Grid, both shadcn generations
- Use direct file imports in examples (no barrel paths)
- Update feature list and documentation links (including Composed Grid / Data Grid)

## Test plan
- [ ] Skim README on GitHub preview for accuracy vs https://niko-table.com
- [ ] Confirm example import paths resolve under `src/components/niko-table/`


Made with [Cursor](https://cursor.com)