### PR TITLE
docs: add README files for grid subdirectories

### DIFF
--- a/src/components/niko-table/grid/README.md
+++ b/src/components/niko-table/grid/README.md
@@ -4,13 +4,15 @@ Optional editable spreadsheet layer on top of the data table. Same open-code / r
 
 ```
 grid/
-├── core/         # useDataGrid wiring via DataGrid, context, feature registration
+├── core/         # DataGrid shell, context, feature registration
 ├── components/   # Clipboard, fill, move, toolbar, status bar, reorder, menus, …
-├── cells/        # Display shell + typed editors (text, number, checkbox, date, select, …)
+├── cells/        # Display shell + typed editors
 ├── hooks/        # useDataGrid, navigation, clipboard, columns, changes, …
 ├── types/        # Cell / row / grid types
 └── config/       # Shortcut metadata
 ```
+
+Each subdirectory has a short `README.md`.
 
 **Composable:** mount only the children you need under `<DataGrid>`. Unmounted features attach no listeners.
 

--- a/src/components/niko-table/grid/cells/README.md
+++ b/src/components/niko-table/grid/cells/README.md
@@ -1,0 +1,20 @@
+# grid/cells/
+
+Display shell and typed editors. Cheap display for every visible cell; heavy editor mounts only while editing. Validity comes from your `resolve` callback.
+
+| File                               | Role                                               |
+| ---------------------------------- | -------------------------------------------------- |
+| `grid-cell-display.tsx`            | Shared display / edit shell (`DataGridCell` usage) |
+| `grid-text-cell.tsx`               | Text editor                                        |
+| `grid-checkbox-cell.tsx`           | Checkbox editor                                    |
+| `grid-date-cell.tsx`               | Date editor                                        |
+| `grid-select-cell.tsx`             | Select editor                                      |
+| `grid-combobox-cell.tsx`           | Combobox / searchable select                       |
+| `grid-marching-ants.tsx`           | Selection outline affordance                       |
+| `cell-props.ts` / `cell-styles.ts` | Shared props and styles                            |
+
+```tsx
+import { GridTextCell } from "@/components/niko-table/grid/cells/grid-text-cell"
+```
+
+Wrap editors in `<DataGridCell>` from `@/components/niko-table/grid/core/data-grid-context`. Parent [README](../README.md) · [Cell types](https://niko-table.com/examples/cell-types-grid/)

--- a/src/components/niko-table/grid/components/README.md
+++ b/src/components/niko-table/grid/components/README.md
@@ -1,0 +1,24 @@
+# grid/components/
+
+Opt-in UI features. Mount as children of `<DataGrid>`. Unmounted pieces attach no listeners.
+
+| File                        | Capability                                 |
+| --------------------------- | ------------------------------------------ |
+| `grid-clipboard.tsx`        | Copy / cut / paste (TSV)                   |
+| `grid-fill-handle.tsx`      | Corner-drag fill                           |
+| `grid-move.tsx`             | Drag selection to move / copy              |
+| `grid-row-reorder.tsx`      | Row drag grip (avoid with active sort)     |
+| `grid-cross-highlight.tsx`  | Row / column chrome for selection          |
+| `grid-status-bar.tsx`       | Count / Sum / Avg / Min / Max              |
+| `grid-toolbar.tsx`          | Undo, redo, add rows, clear, paste hint, … |
+| `grid-row-menu.tsx`         | Context / kebab row actions                |
+| `grid-column-menu.tsx`      | Column header menu options                 |
+| `grid-add-column.tsx`       | Add-column control                         |
+| `grid-shortcuts-dialog.tsx` | Keyboard cheat sheet UI                    |
+
+```tsx
+import { DataGridClipboard } from "@/components/niko-table/grid/components/grid-clipboard"
+import { DataGridFillHandle } from "@/components/niko-table/grid/components/grid-fill-handle"
+```
+
+Parent [README](../README.md) · [Components docs](https://niko-table.com/data-grid/overview/components/)

--- a/src/components/niko-table/grid/config/README.md
+++ b/src/components/niko-table/grid/config/README.md
@@ -1,0 +1,9 @@
+# grid/config/
+
+Discoverable shortcut metadata: the human-readable mirror of `<DataGrid>` key handling. Wire to shortcuts UI via `DataGridShortcutsButton` / list components.
+
+| File                | Role                          |
+| ------------------- | ----------------------------- |
+| `grid-shortcuts.ts` | Shortcut definitions / labels |
+
+Parent [README](../README.md) · [Config docs](https://niko-table.com/data-grid/overview/config/)

--- a/src/components/niko-table/grid/core/README.md
+++ b/src/components/niko-table/grid/core/README.md
@@ -1,0 +1,16 @@
+# grid/core/
+
+Data Grid shell and context. Wrap `DataTable` with `<DataGrid grid={…}>` so keyboard, selection, and opt-in features share one provider.
+
+| File                            | Role                                                     |
+| ------------------------------- | -------------------------------------------------------- |
+| `data-grid.tsx`                 | `<DataGrid>`: nav, selection rectangle, scroll-into-view |
+| `data-grid-context.tsx`         | `useDataGridContext` (throws outside provider)           |
+| `data-grid-columns-context.tsx` | Dynamic column list context                              |
+| `data-grid-features.tsx`        | Feature registration (`useRegisterGridFeature`)          |
+
+```tsx
+import { DataGrid } from "@/components/niko-table/grid/core/data-grid"
+```
+
+Engine hook: [`../hooks/use-data-grid.ts`](../hooks/use-data-grid.ts). Parent [README](../README.md)

--- a/src/components/niko-table/grid/hooks/README.md
+++ b/src/components/niko-table/grid/hooks/README.md
@@ -1,0 +1,19 @@
+# grid/hooks/
+
+Headless Data Grid hooks. Import from the file path.
+
+| Hook                     | Role                                                                     |
+| ------------------------ | ------------------------------------------------------------------------ |
+| `use-data-grid.ts`       | Engine: rows, focus, edit, undo/redo (`useDataGrid`)                     |
+| `use-grid-navigation.ts` | Focus / selection movement                                               |
+| `use-grid-keyboard.ts`   | Key bindings                                                             |
+| `use-grid-clipboard.ts`  | Clipboard helpers                                                        |
+| `use-grid-columns.ts`    | Dynamic column list (`useGridColumns`)                                   |
+| `use-grid-changes.ts`    | Persistence change-set (`useGridChanges`; also shipped as registry item) |
+
+```tsx
+import { useDataGrid } from "@/components/niko-table/grid/hooks/use-data-grid"
+import { useGridChanges } from "@/components/niko-table/grid/hooks/use-grid-changes"
+```
+
+Provider / shell: [`../core/`](../core/). Parent [README](../README.md) · [Hooks docs](https://niko-table.com/data-grid/overview/hooks/)

--- a/src/components/niko-table/grid/types/README.md
+++ b/src/components/niko-table/grid/types/README.md
@@ -1,0 +1,13 @@
+# grid/types/
+
+Shared Data Grid TypeScript types (cell state, row shapes, addresses).
+
+| File           | Role                                          |
+| -------------- | --------------------------------------------- |
+| `grid-cell.ts` | `CellState`, editors, id-addressed cell types |
+
+```tsx
+import type { CellState } from "@/components/niko-table/grid/types/grid-cell"
+```
+
+Parent [README](../README.md) · [Types docs](https://niko-table.com/data-grid/overview/types/)


### PR DESCRIPTION
## Summary
- Add short READMEs under `grid/core`, `components`, `cells`, `hooks`, `types`, and `config`
- Point each folder at imports, sibling layers, and niko-table.com docs

## Test plan
- [ ] Browse `src/components/niko-table/grid/**/README.md` on GitHub
- [ ] Confirm links and file names match the tree


Made with [Cursor](https://cursor.com)