### PR TITLE
fix(niko-table): neutralise spreadsheet formulas in CSV export

### DIFF
--- a/src/components/niko-table/CHANGELOG.md
+++ b/src/components/niko-table/CHANGELOG.md
@@ -27,6 +27,8 @@ All notable changes to the data-table component.
 
 #### Core
 
+- **CSV export neutralises spreadsheet formulas** (`filters/table-export-button`) — `escapeCsvValue` quoted separators and quotes but did nothing about values opening with `=`, `+`, `-`, `@`, tab or carriage return, which Excel, LibreOffice Calc and Google Sheets all evaluate as live formulas. Since rows are arbitrary application data, anyone able to write a record could place executable content in an exported file. Such values are now prefixed with an apostrophe, which every major spreadsheet reads as "the rest is literal text" and does not render. Applied to the array branch as well: quoting is for CSV parsing, not formula prevention — a quoted field opening with `=` is still evaluated.
+
 - **Auto-fit vs. keyboard/autosize resizes** — keyboard nudges and double-click autosize bypass `columnSizingInfo.isResizingColumn`, so auto-fit kept re-fitting over them (a keyboard user shrinking a column got the space redistributed right back). The hook now records the sizing it applied and latches off when `columnSizing` changes to anything it didn't write.
 - **Header-fit label fallback + scope** — floors now use the same fallback chain as the rendered title (`meta.label` → string header → formatted column id), so composable-title columns without `meta.label` get a floor; floors apply only to resizable columns so utility columns (`enableResizing: false`) can't pick up a phantom floor from the id fallback. A JSX `<DataTableColumnTitle title="..." />` override should be mirrored into `meta.label`.
 - **Header-fit re-measure identity** — a re-measure with identical results keeps the previous Map identity, so memoized body rows no longer re-render once after first paint when no floor changed.

--- a/src/components/niko-table/filters/table-export-button.tsx
+++ b/src/components/niko-table/filters/table-export-button.tsx
@@ -21,6 +21,26 @@ import type { DataTableInstance } from "../types"
  * Escape a cell value for CSV output.
  * Handles strings, numbers, booleans, dates, arrays, null, and undefined.
  */
+/**
+ * Characters that make a spreadsheet treat a cell as a live formula.
+ *
+ * Excel, LibreOffice Calc and Google Sheets all evaluate a cell beginning with
+ * one of these, so an exported value like `=cmd|'/c calc'!A1` becomes
+ * executable content when the file is opened. Table rows are arbitrary
+ * application data, so anyone who can write a record can reach the export.
+ */
+const FORMULA_TRIGGER_PATTERN = /^[=+\-@\t\r]/
+
+/**
+ * Prefix a value a spreadsheet would evaluate with an apostrophe, which every
+ * major spreadsheet reads as "treat the rest as literal text" and does not
+ * render in the cell. Applied before quoting so the apostrophe is inside the
+ * quoted field.
+ */
+function neutralizeFormula(str: string): string {
+  return FORMULA_TRIGGER_PATTERN.test(str) ? `'${str}` : str
+}
+
 function escapeCsvValue(value: unknown): string {
   if (value === null || value === undefined) return ""
 
@@ -29,7 +49,9 @@ function escapeCsvValue(value: unknown): string {
   }
 
   if (Array.isArray(value)) {
-    const joined = value.map(String).join(", ")
+    // Neutralised too: quoting is for CSV parsing, not formula prevention —
+    // a spreadsheet still evaluates a quoted field that opens with `=`.
+    const joined = neutralizeFormula(value.map(String).join(", "))
     return `"${joined.replace(/"/g, '""')}"`
   }
 
@@ -47,8 +69,8 @@ function escapeCsvValue(value: unknown): string {
     }
   }
 
-  // Default: treat as string and escape quotes
-  const str = String(value)
+  // Default: treat as string, neutralise formulas, then escape quotes
+  const str = neutralizeFormula(String(value))
   // Wrap in quotes if the value contains commas, quotes, or newlines
   if (str.includes(",") || str.includes('"') || str.includes("\n")) {
     return `"${str.replace(/"/g, '""')}"`


### PR DESCRIPTION
`escapeCsvValue` quotes separators and quotes, but does nothing about values that begin with `=`, `+`, `-`, `@`, tab or carriage return. Excel, LibreOffice Calc and Google Sheets all treat such a cell as a live formula, so a stored value like `=cmd|'/c calc'!A1` becomes executable content when the exported file is opened.

Table rows are arbitrary application data, so anyone able to write a record can reach the export. This is the standard CSV injection / formula injection class ([OWASP](https://owasp.org/www-community/attacks/CSV_Injection)).

### Fix

Values matching `/^[=+\-@\t\r]/` are prefixed with an apostrophe, which every major spreadsheet reads as "treat the rest as literal text" and does not render in the cell.

```ts
const FORMULA_TRIGGER_PATTERN = /^[=+\-@\t\r]/

function neutralizeFormula(str: string): string {
  return FORMULA_TRIGGER_PATTERN.test(str) ? `'${str}` : str
}
```

### Applied to the array branch too

Worth calling out, because it is easy to assume quoting is enough: **quoting is for CSV parsing, not formula prevention.** A spreadsheet still evaluates a quoted field that opens with `=`, so `Array.isArray(value)` — which joins and quotes — needed the same treatment.

The other branches are safe by construction: `Date` yields an ISO string, JSON-encoded objects open with `{`, and booleans/numbers cannot match the pattern.

### Not changed

Header cells (`escapeCsvValue(label ?? column.id)`) go through the same function, so column ids and labels are covered by the same fix.
